### PR TITLE
Feature/score

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApi.java
@@ -1,9 +1,9 @@
-package com.playkuround.playkuroundserver.domain.landmark.api;
+package com.playkuround.playkuroundserver.domain.adventure.api;
 
-import com.playkuround.playkuroundserver.domain.landmark.application.AdventureService;
-import com.playkuround.playkuroundserver.domain.landmark.dto.RequestSaveAdventure;
-import com.playkuround.playkuroundserver.domain.landmark.dto.ResponseFindAdventure;
-import com.playkuround.playkuroundserver.domain.landmark.dto.ResponseMostLandmarkUser;
+import com.playkuround.playkuroundserver.domain.adventure.application.AdventureService;
+import com.playkuround.playkuroundserver.domain.adventure.dto.RequestSaveAdventure;
+import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseFindAdventure;
+import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseMostLandmarkUser;
 import com.playkuround.playkuroundserver.global.resolver.UserEmail;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -48,7 +48,7 @@ public class AdventureService {
 
     private void validateLocation(Landmark landmark, Double latitude, Double longitude) {
         // TODO 랜드마크와 현재 위치에 대한 거리 검증 -> 검증 실패면 에러 발생
-        // 검증 실패일 경우, 발생하는 오류 -> LocationValidateException
+        // 검증 실패일 경우, 발생하는 오류 -> LocationInvalidException
     }
 
     public List<ResponseFindAdventure> findAdventureByUserEmail(String userEmail) {

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -1,13 +1,13 @@
-package com.playkuround.playkuroundserver.domain.landmark.application;
+package com.playkuround.playkuroundserver.domain.adventure.application;
 
-import com.playkuround.playkuroundserver.domain.landmark.dao.AdventureRepository;
+import com.playkuround.playkuroundserver.domain.adventure.dao.AdventureRepository;
 import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
-import com.playkuround.playkuroundserver.domain.landmark.domain.Adventure;
+import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
-import com.playkuround.playkuroundserver.domain.landmark.dto.MostVisitedInfo;
-import com.playkuround.playkuroundserver.domain.landmark.dto.RequestSaveAdventure;
-import com.playkuround.playkuroundserver.domain.landmark.dto.ResponseFindAdventure;
-import com.playkuround.playkuroundserver.domain.landmark.dto.ResponseMostLandmarkUser;
+import com.playkuround.playkuroundserver.domain.adventure.dto.MostVisitedInfo;
+import com.playkuround.playkuroundserver.domain.adventure.dto.RequestSaveAdventure;
+import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseFindAdventure;
+import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseMostLandmarkUser;
 import com.playkuround.playkuroundserver.domain.landmark.exception.LandmarkNotFoundException;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
@@ -1,6 +1,6 @@
-package com.playkuround.playkuroundserver.domain.landmark.dao;
+package com.playkuround.playkuroundserver.domain.adventure.dao;
 
-import com.playkuround.playkuroundserver.domain.landmark.domain.Adventure;
+import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/domain/Adventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/domain/Adventure.java
@@ -1,6 +1,7 @@
-package com.playkuround.playkuroundserver.domain.landmark.domain;
+package com.playkuround.playkuroundserver.domain.adventure.domain;
 
 import com.playkuround.playkuroundserver.domain.common.BaseTimeEntity;
+import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/MostVisitedInfo.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/MostVisitedInfo.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.landmark.dto;
+package com.playkuround.playkuroundserver.domain.adventure.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/RequestSaveAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/RequestSaveAdventure.java
@@ -1,6 +1,9 @@
 package com.playkuround.playkuroundserver.domain.adventure.dto;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.validation.constraints.NotNull;
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/RequestSaveAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/RequestSaveAdventure.java
@@ -1,12 +1,11 @@
 package com.playkuround.playkuroundserver.domain.adventure.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotNull;
 
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class RequestSaveAdventure {

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/RequestSaveAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/RequestSaveAdventure.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.landmark.dto;
+package com.playkuround.playkuroundserver.domain.adventure.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
@@ -1,7 +1,10 @@
 package com.playkuround.playkuroundserver.domain.adventure.dto;
 
 import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
@@ -1,11 +1,13 @@
 package com.playkuround.playkuroundserver.domain.adventure.dto;
 
-import lombok.Builder;
-import lombok.Data;
+import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
 public class ResponseFindAdventure {
 
     private Long landmarkId;
@@ -15,5 +17,12 @@ public class ResponseFindAdventure {
     public ResponseFindAdventure(Long landmarkId, LocalDateTime visitedDateTime) {
         this.landmarkId = landmarkId;
         this.visitedDateTime = visitedDateTime;
+    }
+
+    public static ResponseFindAdventure of(Adventure adventure) {
+        return ResponseFindAdventure.builder()
+                .landmarkId(adventure.getLandmark().getId())
+                .visitedDateTime(adventure.getCreateAt())
+                .build();
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.landmark.dto;
+package com.playkuround.playkuroundserver.domain.adventure.dto;
 
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseMostLandmarkUser.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseMostLandmarkUser.java
@@ -3,8 +3,11 @@ package com.playkuround.playkuroundserver.domain.adventure.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 public class ResponseMostLandmarkUser {
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseMostLandmarkUser.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseMostLandmarkUser.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.landmark.dto;
+package com.playkuround.playkuroundserver.domain.adventure.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/exception/LocationInvalidException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/exception/LocationInvalidException.java
@@ -3,9 +3,9 @@ package com.playkuround.playkuroundserver.domain.adventure.exception;
 import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
 import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;
 
-public class LocationValidateException extends BusinessException {
+public class LocationInvalidException extends BusinessException {
 
-    public LocationValidateException() {
+    public LocationInvalidException() {
         super(ErrorCode.LOCATION_INVALID);
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/exception/LocationValidateException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/exception/LocationValidateException.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.landmark.exception;
+package com.playkuround.playkuroundserver.domain.adventure.exception;
 
 import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
 import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/exception/LocationValidateException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/exception/LocationValidateException.java
@@ -6,7 +6,7 @@ import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;
 public class LocationValidateException extends BusinessException {
 
     public LocationValidateException() {
-        super(ErrorCode.LOCATION_VALIDATE);
+        super(ErrorCode.LOCATION_INVALID);
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/api/ScoreApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/api/ScoreApi.java
@@ -1,0 +1,28 @@
+package com.playkuround.playkuroundserver.domain.score.api;
+
+import com.playkuround.playkuroundserver.domain.score.application.ScoreService;
+import com.playkuround.playkuroundserver.domain.score.dto.SaveScore;
+import com.playkuround.playkuroundserver.global.resolver.UserEmail;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/scores")
+public class ScoreApi {
+
+    private final ScoreService scoreService;
+
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void saveAdventure(@UserEmail String userEmail, @RequestBody @Valid SaveScore saveScore) {
+        scoreService.saveScore(userEmail, saveScore);
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
@@ -1,0 +1,26 @@
+package com.playkuround.playkuroundserver.domain.score.application;
+
+import com.playkuround.playkuroundserver.domain.score.dao.ScoreRepository;
+import com.playkuround.playkuroundserver.domain.score.dto.SaveScore;
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScoreService {
+
+    private final ScoreRepository scoreRepository;
+    private final UserFindDao userFindDao;
+
+    public void saveScore(String userEmail, SaveScore saveScore) {
+        // TODO 검증의 범위는 어디까지? 예를 들면, 진짜로 유저가 탐험을 했는지 안했는지 확인까지 해야하는가?
+        User user = userFindDao.findByEmail(userEmail);
+
+        scoreRepository.save(saveScore.toEntity(user));
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
@@ -23,12 +23,4 @@ public class ScoreService {
         scoreRepository.save(saveScore.toEntity(user));
     }
 
-    public int getTotalScorePointByUserEmail(String email) {
-        User user = userFindDao.findByEmail(email);
-
-        return scoreRepository.findByUser(user).stream()
-                .mapToInt(score -> score.getScoreType().getPoint())
-                .sum();
-    }
-
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
@@ -23,4 +23,12 @@ public class ScoreService {
         scoreRepository.save(saveScore.toEntity(user));
     }
 
+    public int getTotalScorePointByUserEmail(String email) {
+        User user = userFindDao.findByEmail(email);
+
+        return scoreRepository.findByUser(user).stream()
+                .mapToInt(score -> score.getScoreType().getPoint())
+                .sum();
+    }
+
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/dao/ScoreFindDao.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/dao/ScoreFindDao.java
@@ -1,0 +1,24 @@
+package com.playkuround.playkuroundserver.domain.score.dao;
+
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScoreFindDao {
+
+    private final ScoreRepository scoreRepository;
+    private final UserFindDao userFindDao;
+
+    public int findTotalScorePointByUserEmail(String email) {
+        User user = userFindDao.findByEmail(email);
+
+        return scoreRepository.findByUser(user).stream()
+                .mapToInt(score -> score.getScoreType().getPoint())
+                .sum();
+    }
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/dao/ScoreRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/dao/ScoreRepository.java
@@ -1,0 +1,7 @@
+package com.playkuround.playkuroundserver.domain.score.dao;
+
+import com.playkuround.playkuroundserver.domain.score.domain.Score;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScoreRepository extends JpaRepository<Score, Long> {
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/dao/ScoreRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/dao/ScoreRepository.java
@@ -1,7 +1,11 @@
 package com.playkuround.playkuroundserver.domain.score.dao;
 
 import com.playkuround.playkuroundserver.domain.score.domain.Score;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ScoreRepository extends JpaRepository<Score, Long> {
+    List<Score> findByUser(User user);
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/domain/Score.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/domain/Score.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.score.domain;
 import com.playkuround.playkuroundserver.domain.common.BaseTimeEntity;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Fetch;
@@ -26,4 +27,9 @@ public class Score extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ScoreType scoreType;
 
+    @Builder
+    public Score(User user, ScoreType scoreType) {
+        this.user = user;
+        this.scoreType = scoreType;
+    }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/domain/ScoreType.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/domain/ScoreType.java
@@ -1,4 +1,15 @@
 package com.playkuround.playkuroundserver.domain.score.domain;
 
 public enum ScoreType {
+    ATTENDANCE(1), ADVENTURE(5), EXTRA_ADVENTURE(1);
+
+    private final int point;
+
+    ScoreType(int point) {
+        this.point = point;
+    }
+
+    public int getPoint() {
+        return point;
+    }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/dto/SaveScore.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/dto/SaveScore.java
@@ -1,0 +1,33 @@
+package com.playkuround.playkuroundserver.domain.score.dto;
+
+import com.playkuround.playkuroundserver.domain.score.domain.Score;
+import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
+import com.playkuround.playkuroundserver.domain.score.exception.ScoreTypeNotMatchException;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import java.util.Objects;
+
+@Getter
+@Setter
+public class SaveScore {
+
+    @NotBlank
+    private String scoreType;
+
+    private ScoreType getScoreType() {
+        if (Objects.equals(scoreType, ScoreType.ADVENTURE.name())) return ScoreType.ADVENTURE;
+        else if (Objects.equals(scoreType, ScoreType.ATTENDANCE.name())) return ScoreType.ATTENDANCE;
+        else if (Objects.equals(scoreType, ScoreType.EXTRA_ADVENTURE.name())) return ScoreType.EXTRA_ADVENTURE;
+        else throw new ScoreTypeNotMatchException();
+    }
+
+    public Score toEntity(User user) {
+        return Score.builder()
+                .user(user)
+                .scoreType(getScoreType())
+                .build();
+    }
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/dto/SaveScore.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/dto/SaveScore.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 @AllArgsConstructor
 public class SaveScore {
 
-    @NotBlank
+    @NotBlank(message = "scoreType은 필수입니다.")
     private String scoreType;
 
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/dto/SaveScore.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/dto/SaveScore.java
@@ -4,7 +4,9 @@ import com.playkuround.playkuroundserver.domain.score.domain.Score;
 import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
 import com.playkuround.playkuroundserver.domain.score.exception.ScoreTypeNotMatchException;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
@@ -12,12 +14,15 @@ import java.util.Objects;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class SaveScore {
 
     @NotBlank
     private String scoreType;
 
-    private ScoreType getScoreType() {
+
+    private ScoreType convertScoreType() {
         if (Objects.equals(scoreType, ScoreType.ADVENTURE.name())) return ScoreType.ADVENTURE;
         else if (Objects.equals(scoreType, ScoreType.ATTENDANCE.name())) return ScoreType.ATTENDANCE;
         else if (Objects.equals(scoreType, ScoreType.EXTRA_ADVENTURE.name())) return ScoreType.EXTRA_ADVENTURE;
@@ -27,7 +32,7 @@ public class SaveScore {
     public Score toEntity(User user) {
         return Score.builder()
                 .user(user)
-                .scoreType(getScoreType())
+                .scoreType(convertScoreType())
                 .build();
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/exception/ScoreTypeNotMatchException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/exception/ScoreTypeNotMatchException.java
@@ -1,0 +1,11 @@
+package com.playkuround.playkuroundserver.domain.score.exception;
+
+import com.playkuround.playkuroundserver.global.error.exception.InvalidValueException;
+
+public class ScoreTypeNotMatchException extends InvalidValueException {
+
+    public ScoreTypeNotMatchException() {
+        super("scoreType이 올바르지 않습니다.");
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
     NOT_ACCESS_TOKEN_TYPE(401, "A005", "TokenType이 Access Token이 아닙니다."),
 
     // Adventure, Landmark,
-    LOCATION_VALIDATE(401, "L001", "현재 위치와 랜드마크 위치가 너무 멉니다.")
+    LOCATION_INVALID(401, "L001", "현재 위치와 랜드마크 위치가 너무 멉니다.")
 
     ;
 

--- a/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     ACCESS_TOKEN_EXPIRED(401, "A004", "해당 Access Token은 만료되었습니다."),
     NOT_ACCESS_TOKEN_TYPE(401, "A005", "TokenType이 Access Token이 아닙니다."),
 
-    // Adventure, Landmark,
+    // Adventure
     LOCATION_INVALID(401, "L001", "현재 위치와 랜드마크 위치가 너무 멉니다.")
 
     ;

--- a/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApiTest.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.landmark.api;
+package com.playkuround.playkuroundserver.domain.adventure.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/ScoreApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/ScoreApiTest.java
@@ -2,6 +2,7 @@ package com.playkuround.playkuroundserver.domain.adventure.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.playkuround.playkuroundserver.domain.score.application.ScoreService;
+import com.playkuround.playkuroundserver.domain.score.dao.ScoreFindDao;
 import com.playkuround.playkuroundserver.domain.score.dao.ScoreRepository;
 import com.playkuround.playkuroundserver.domain.score.domain.Score;
 import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
@@ -50,6 +51,9 @@ class ScoreApiTest {
     private UserRepository userRepository;
 
     @Autowired
+    private ScoreFindDao scoreFindDao;
+
+    @Autowired
     private MockMvc mockMvc;
 
     @AfterEach
@@ -86,7 +90,7 @@ class ScoreApiTest {
         assertEquals(1L, scoreRepository.count());
         Score score = scoreRepository.findAll().get(0);
         assertEquals(ScoreType.ATTENDANCE, score.getScoreType());
-        assertEquals(ScoreType.ATTENDANCE.getPoint(), scoreService.getTotalScorePointByUserEmail(userEmail));
+        assertEquals(ScoreType.ATTENDANCE.getPoint(), scoreFindDao.findTotalScorePointByUserEmail(userEmail));
     }
 
     @Test
@@ -107,7 +111,7 @@ class ScoreApiTest {
         assertEquals(1L, scoreRepository.count());
         Score score = scoreRepository.findAll().get(0);
         assertEquals(ScoreType.ADVENTURE, score.getScoreType());
-        assertEquals(ScoreType.ADVENTURE.getPoint(), scoreService.getTotalScorePointByUserEmail(userEmail));
+        assertEquals(ScoreType.ADVENTURE.getPoint(), scoreFindDao.findTotalScorePointByUserEmail(userEmail));
     }
 
     @Test
@@ -128,7 +132,7 @@ class ScoreApiTest {
         assertEquals(1L, scoreRepository.count());
         Score score = scoreRepository.findAll().get(0);
         assertEquals(ScoreType.EXTRA_ADVENTURE, score.getScoreType());
-        assertEquals(ScoreType.EXTRA_ADVENTURE.getPoint(), scoreService.getTotalScorePointByUserEmail(userEmail));
+        assertEquals(ScoreType.EXTRA_ADVENTURE.getPoint(), scoreFindDao.findTotalScorePointByUserEmail(userEmail));
     }
 
 }

--- a/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/ScoreApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/ScoreApiTest.java
@@ -1,0 +1,134 @@
+package com.playkuround.playkuroundserver.domain.adventure.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.playkuround.playkuroundserver.domain.score.application.ScoreService;
+import com.playkuround.playkuroundserver.domain.score.dao.ScoreRepository;
+import com.playkuround.playkuroundserver.domain.score.domain.Score;
+import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
+import com.playkuround.playkuroundserver.domain.score.dto.SaveScore;
+import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
+import com.playkuround.playkuroundserver.domain.user.application.UserRegisterService;
+import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
+import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc //MockMvc 사용
+@SpringBootTest
+@ActiveProfiles("test")
+class ScoreApiTest {
+
+    @Autowired
+    private ObjectMapper objectMapper; // 스프링에서 자동으로 주입해줌
+
+    @Autowired
+    private UserRegisterService userRegisterService;
+
+    @Autowired
+    private ScoreService scoreService;
+
+    @Autowired
+    private UserLoginService userLoginService;
+
+    @Autowired
+    private ScoreRepository scoreRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @AfterEach
+    void clean() {
+        scoreRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private final String userEmail = "test@email.com";
+    private String accessToken;
+
+
+    @BeforeEach
+    void registerUser() {
+        userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
+        accessToken = userLoginService.login(userEmail).getAccessToken();
+    }
+
+    @Test
+    @DisplayName("score 저장(출석)")
+    void saveScoreAttendance() throws Exception {
+        // given
+        String content = objectMapper.writeValueAsString(new SaveScore("ATTENDANCE"));
+
+        // expected
+        mockMvc.perform(post("/api/scores")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isCreated())
+                .andDo(print());
+
+        assertEquals(1L, scoreRepository.count());
+        Score score = scoreRepository.findAll().get(0);
+        assertEquals(ScoreType.ATTENDANCE, score.getScoreType());
+        assertEquals(ScoreType.ATTENDANCE.getPoint(), scoreService.getTotalScorePointByUserEmail(userEmail));
+    }
+
+    @Test
+    @DisplayName("score 저장(탐험)")
+    void saveScoreAdventure() throws Exception {
+        // given
+        String content = objectMapper.writeValueAsString(new SaveScore("ADVENTURE"));
+
+        // expected
+        mockMvc.perform(post("/api/scores")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isCreated())
+                .andDo(print());
+
+        assertEquals(1L, scoreRepository.count());
+        Score score = scoreRepository.findAll().get(0);
+        assertEquals(ScoreType.ADVENTURE, score.getScoreType());
+        assertEquals(ScoreType.ADVENTURE.getPoint(), scoreService.getTotalScorePointByUserEmail(userEmail));
+    }
+
+    @Test
+    @DisplayName("score 저장(추가 탐험)")
+    void saveScoreExtraAdventure() throws Exception {
+        // given
+        String content = objectMapper.writeValueAsString(new SaveScore("EXTRA_ADVENTURE"));
+
+        // expected
+        mockMvc.perform(post("/api/scores")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isCreated())
+                .andDo(print());
+
+        assertEquals(1L, scoreRepository.count());
+        Score score = scoreRepository.findAll().get(0);
+        assertEquals(ScoreType.EXTRA_ADVENTURE, score.getScoreType());
+        assertEquals(ScoreType.EXTRA_ADVENTURE.getPoint(), scoreService.getTotalScorePointByUserEmail(userEmail));
+    }
+
+}

--- a/src/test/java/com/playkuround/playkuroundserver/domain/landmark/api/AdventureApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/landmark/api/AdventureApiTest.java
@@ -2,11 +2,11 @@ package com.playkuround.playkuroundserver.domain.landmark.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.playkuround.playkuroundserver.domain.landmark.application.AdventureService;
-import com.playkuround.playkuroundserver.domain.landmark.dao.AdventureRepository;
-import com.playkuround.playkuroundserver.domain.landmark.domain.Adventure;
-import com.playkuround.playkuroundserver.domain.landmark.dto.RequestSaveAdventure;
-import com.playkuround.playkuroundserver.domain.landmark.dto.ResponseFindAdventure;
+import com.playkuround.playkuroundserver.domain.adventure.application.AdventureService;
+import com.playkuround.playkuroundserver.domain.adventure.dao.AdventureRepository;
+import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
+import com.playkuround.playkuroundserver.domain.adventure.dto.RequestSaveAdventure;
+import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseFindAdventure;
 import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
 import com.playkuround.playkuroundserver.domain.user.application.UserRegisterService;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;

--- a/src/test/java/com/playkuround/playkuroundserver/domain/landmark/api/AdventureApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/landmark/api/AdventureApiTest.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -36,7 +37,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc //MockMvc 사용
-@SpringBootTest(properties = {"spring.config.location=classpath:application-test.yml"})
+@SpringBootTest
+@ActiveProfiles("test")
 class AdventureApiTest {
 
     @Autowired
@@ -148,7 +150,7 @@ class AdventureApiTest {
                         .header("Authorization", "Bearer " + accessToken)
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("해당 장소에 방문한 회원이 한 명도 없습니다."))
+                .andExpect(jsonPath("$.message").value("해당 장소에 방문한 회원이 없습니다."))
                 .andExpect(jsonPath("$.count").value(0))
                 .andDo(print());
 


### PR DESCRIPTION
## 요약
Score api 개발
ScoreFindDao 개발
리팩토링

<br>

## 작업 내용
### 1. Score API (POST /api/scores)
- 요청 헤더(Authorization)의 액세스 토큰을 통해 이메일 획득
- 요청 바디에 `scoreType`가 필요
  - ATTENDANCE : 출석 체크 점수 -> 1점
  - ADVENTURE : 탐험 점수 -> 5점
  - EXTRA_ADVENTURE : 중복 탐험 점수 -> 1점
  - 그 외의 String value는 모두 에러 발생합니다.
- 응답 바디는 없으며, HttpStatus는 201입니다.

<br>

### 2. ScoreFindDao 개발
- 메서드 원형 : `int findTotalScorePointByUserEmail(String email)`
- 인자로 userEmail을 넣으면, 해당 유저의 총 점수가 리턴됩니다.

<br>

### 3. 리펙토링
- 저번 PR의 코멘트를 바탕으로 코드 리펙터링 했습니다.