### PR TITLE
인증 메일 전송 및 인증코드 일치 확인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -1,18 +1,17 @@
 package com.playkuround.playkuroundserver.domain.adventure.application;
 
 import com.playkuround.playkuroundserver.domain.adventure.dao.AdventureRepository;
-import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
 import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
-import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.adventure.dto.MostVisitedInfo;
 import com.playkuround.playkuroundserver.domain.adventure.dto.RequestSaveAdventure;
 import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseFindAdventure;
 import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseMostLandmarkUser;
+import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
+import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.landmark.exception.LandmarkNotFoundException;
 import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
-import com.playkuround.playkuroundserver.domain.user.exception.UserNotFoundException;
 import com.playkuround.playkuroundserver.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -74,9 +73,9 @@ public class AdventureService {
                 .forEach(adventure -> {
                     Long userId = adventure.getUser().getId();
                     if (count.containsKey(userId)) {
-                        count.get(userId).updateData(adventure.getCreateAt());
+                        count.get(userId).updateData(adventure.getCreatedAt());
                     } else {
-                        count.put(userId, new MostVisitedInfo(userId, adventure.getCreateAt()));
+                        count.put(userId, new MostVisitedInfo(userId, adventure.getCreatedAt()));
                     }
                 });
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
@@ -25,7 +25,7 @@ public class ResponseFindAdventure {
     public static ResponseFindAdventure of(Adventure adventure) {
         return ResponseFindAdventure.builder()
                 .landmarkId(adventure.getLandmark().getId())
-                .visitedDateTime(adventure.getCreateAt())
+                .visitedDateTime(adventure.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchService.java
@@ -23,9 +23,9 @@ public class AttendanceSearchService {
 
     public List<LocalDateTime> findByUserMonthLong(String userEmail) {
         User user = userFindDao.findByEmail(userEmail);
-        List<Attendance> attendances = attendanceRepository.findByUserAndCreateAtAfter(user, LocalDateTime.now().minusMonths(1));
+        List<Attendance> attendances = attendanceRepository.findByUserAndCreatedAtAfter(user, LocalDateTime.now().minusMonths(1));
         return attendances.stream()
-                .map(BaseTimeEntity::getCreateAt)
+                .map(BaseTimeEntity::getCreatedAt)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/dao/AttendanceRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/dao/AttendanceRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
-    List<Attendance> findByUserAndCreateAtAfter(User user, LocalDateTime localDateTime);
+    List<Attendance> findByUserAndCreatedAtAfter(User user, LocalDateTime localDateTime);
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/api/AuthEmailApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/api/AuthEmailApi.java
@@ -1,0 +1,37 @@
+package com.playkuround.playkuroundserver.domain.auth.email.api;
+
+import com.playkuround.playkuroundserver.domain.auth.email.application.AuthEmailSendService;
+import com.playkuround.playkuroundserver.domain.auth.email.application.AuthEmailVerifyService;
+import com.playkuround.playkuroundserver.domain.auth.email.dto.AuthEmailSendDto;
+import com.playkuround.playkuroundserver.domain.auth.exception.NotKUEmailException;
+import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
+import com.playkuround.playkuroundserver.global.util.ApiUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/emails")
+public class AuthEmailApi {
+
+    private final AuthEmailSendService authEmailSendService;
+    private final AuthEmailVerifyService authEmailVerifyService;
+
+    @PostMapping
+    public ApiResponse<AuthEmailSendDto.Response> authEmailSend(@RequestBody @Valid AuthEmailSendDto.Request requestDto) {
+        if (!requestDto.getTarget().split("@")[1].equals("konkuk.ac.kr")) {
+            throw new NotKUEmailException();
+        }
+        AuthEmailSendDto.Response responseDto = authEmailSendService.sendAuthEmail(requestDto);
+        return ApiUtils.success(responseDto);
+    }
+
+    @GetMapping
+    public ApiResponse<Boolean> authEmailVerify(@RequestParam("code") String code, @RequestParam("email") String email) {
+        boolean result = authEmailVerifyService.verifyAuthEmail(code, email);
+        return ApiUtils.success(result);
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailSendService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailSendService.java
@@ -1,0 +1,82 @@
+package com.playkuround.playkuroundserver.domain.auth.email.application;
+
+import com.playkuround.playkuroundserver.domain.auth.email.dao.AuthEmailRepository;
+import com.playkuround.playkuroundserver.domain.auth.email.domain.AuthEmail;
+import com.playkuround.playkuroundserver.domain.auth.email.dto.AuthEmailSendDto;
+import com.playkuround.playkuroundserver.infra.email.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class AuthEmailSendService {
+
+    private final EmailService emailService;
+    private final AuthEmailRepository authEmailRepository;
+
+    @Transactional
+    public AuthEmailSendDto.Response sendAuthEmail(AuthEmailSendDto.Request requestDto) {
+        String target = requestDto.getTarget();
+        String title = "[플레이쿠라운드] 회원가입 인증코드입니다.";
+        String code = createCode();
+        String content = createContent(code);
+
+        emailService.sendMessage(target, title, content);
+
+        LocalDateTime expiredAt = LocalDateTime.now().plusMinutes(5);
+        AuthEmail authEmail = AuthEmail.createAuthEmail(target, code, expiredAt);
+        authEmailRepository.save(authEmail);
+
+        return AuthEmailSendDto.Response.of(expiredAt);
+    }
+
+    private String createContent(String code) {
+        String content = "<div>" +
+                "<h2>안녕하세요, 플레이쿠라운드입니다.</h1>" +
+                "<div font-family:verdana'>" +
+                "<p>아래 인증코드를 회원가입 창으로 돌아가 입력해주세요.<p>" +
+                "<p>회원가입 인증코드입니다.<p>" +
+                "<div style='font-size:130%'>" +
+                "<strong>" +
+                code +
+                "</strong>" +
+                "<div>" +
+                "<br> " +
+                "</div>" +
+                "<br>" +
+                "</div>";
+
+        return content;
+    }
+
+    private static String createCode() {
+        StringBuilder code = new StringBuilder();
+        Random random = new Random();
+
+        for (int i = 0; i < 6; i++) {
+            int type = random.nextInt(3);
+
+            switch (type) {
+                case 0:
+                    // 알파벳 소문자(a~z)
+                    code.append((char) (int)(random.nextInt(26) + 97));
+                    break;
+                case 1:
+                    // 알파벳 대문자(A~Z)
+                    code.append((char) (random.nextInt(26) + 65));
+                    break;
+                case 2:
+                    // 정수 0~9
+                    code.append(random.nextInt(10));
+                    break;
+            }
+        }
+
+        return code.toString();
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailVerifyService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailVerifyService.java
@@ -1,0 +1,31 @@
+package com.playkuround.playkuroundserver.domain.auth.email.application;
+
+import com.playkuround.playkuroundserver.domain.auth.email.dao.AuthEmailRepository;
+import com.playkuround.playkuroundserver.domain.auth.email.domain.AuthEmail;
+import com.playkuround.playkuroundserver.domain.auth.exception.AuthCodeExpiredException;
+import com.playkuround.playkuroundserver.domain.auth.exception.AuthEmailNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthEmailVerifyService {
+
+    private final AuthEmailRepository authEmailRepository;
+
+    public boolean verifyAuthEmail(String code, String email) {
+        AuthEmail authEmail = authEmailRepository.findFirstByTargetOrderByCreatedAtDesc(email)
+                .orElseThrow(() -> new AuthEmailNotFoundException(email));
+
+        if (authEmail.getExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new AuthCodeExpiredException();
+        }
+
+        return authEmail.getCode().equals(code);
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/dao/AuthEmailRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/dao/AuthEmailRepository.java
@@ -1,0 +1,12 @@
+package com.playkuround.playkuroundserver.domain.auth.email.dao;
+
+import com.playkuround.playkuroundserver.domain.auth.email.domain.AuthEmail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AuthEmailRepository extends JpaRepository<AuthEmail, Long> {
+
+    Optional<AuthEmail> findFirstByTargetOrderByCreatedAtDesc(String target);
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/domain/AuthEmail.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/domain/AuthEmail.java
@@ -1,0 +1,45 @@
+package com.playkuround.playkuroundserver.domain.auth.email.domain;
+
+import com.playkuround.playkuroundserver.domain.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthEmail extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String target;
+
+    @Column(nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Builder
+    public AuthEmail(String target, String code, LocalDateTime expiredAt) {
+        this.code = code;
+        this.target = target;
+        this.expiredAt = expiredAt;
+    }
+
+    public static AuthEmail createAuthEmail(String target, String code, LocalDateTime expireAt) {
+        return AuthEmail.builder()
+                .target(target)
+                .code(code)
+                .expiredAt(expireAt)
+                .build();
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/dto/AuthEmailSendDto.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/dto/AuthEmailSendDto.java
@@ -1,0 +1,39 @@
+package com.playkuround.playkuroundserver.domain.auth.email.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+public class AuthEmailSendDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Request {
+        @NotBlank
+        @Email
+        private String target;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Response {
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime expireAt;
+
+        public static Response of(LocalDateTime expireAt) {
+            return Response.builder()
+                    .expireAt(expireAt)
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/exception/AuthCodeExpiredException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/exception/AuthCodeExpiredException.java
@@ -1,0 +1,12 @@
+package com.playkuround.playkuroundserver.domain.auth.exception;
+
+import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
+import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;
+
+public class AuthCodeExpiredException extends BusinessException {
+
+    public AuthCodeExpiredException() {
+        super(ErrorCode.EXPIRED_AUTH_CODE);
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/exception/AuthEmailNotFoundException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/exception/AuthEmailNotFoundException.java
@@ -1,0 +1,11 @@
+package com.playkuround.playkuroundserver.domain.auth.exception;
+
+import com.playkuround.playkuroundserver.global.error.exception.EntityNotFoundException;
+
+public class AuthEmailNotFoundException extends EntityNotFoundException {
+
+    public AuthEmailNotFoundException(String target) {
+        super(target + " 의 AuthEmail 엔티티 조회에 실패하였습니다.");
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/exception/NotKUEmailException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/exception/NotKUEmailException.java
@@ -1,0 +1,12 @@
+package com.playkuround.playkuroundserver.domain.auth.exception;
+
+import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
+import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;
+
+public class NotKUEmailException extends BusinessException {
+
+    public NotKUEmailException() {
+        super(ErrorCode.NOT_KU_EMAIL);
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/common/BaseTimeEntity.java
@@ -17,7 +17,7 @@ public abstract class BaseTimeEntity {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)

--- a/src/main/java/com/playkuround/playkuroundserver/global/config/WebConfig.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/config/WebConfig.java
@@ -24,7 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(authenticationInterceptor)
                 .order(1)
                 .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/users/register", "/api/users/duplication", "/api/auth/tokens")
+                .excludePathPatterns("/api/users/register", "/api/users/duplication", "/api/auth/tokens", "/api/auth/emails")
         ;
 
     }

--- a/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
@@ -31,7 +31,12 @@ public enum ErrorCode {
     LOCATION_INVALID(401, "L001", "현재 위치와 랜드마크 위치가 너무 멉니다."),
 
     // Score
-    INVALID_SCORE_TYPE(401, "S001", "올바르지 않은 ScoreType입니다.")
+    INVALID_SCORE_TYPE(401, "S001", "올바르지 않은 ScoreType입니다."),
+
+    // Email
+    NOT_KU_EMAIL(400, "E001", "건국대학교 이메일이 아닙니다."),
+    EMAIL_SEND_FAIL(500, "E002", "이메일 전송에 실패하였습니다."),
+    EXPIRED_AUTH_CODE(400, "E003", "만료된 코드입니다."),
 
     ;
 

--- a/src/main/java/com/playkuround/playkuroundserver/infra/email/EmailService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/infra/email/EmailService.java
@@ -1,0 +1,34 @@
+package com.playkuround.playkuroundserver.infra.email;
+
+import com.playkuround.playkuroundserver.infra.email.exception.EmailSendFailException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendMessage(String target, String title, String content) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+
+            message.addRecipients(MimeMessage.RecipientType.TO, target);
+            message.setSubject(title);
+            message.setText(content, "UTF-8", "HTML");
+            message.setFrom(new InternetAddress("playkuround@gmail.com", "플레이쿠라운드"));
+
+            mailSender.send(message);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            throw new EmailSendFailException();
+        }
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/infra/email/exception/EmailSendFailException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/infra/email/exception/EmailSendFailException.java
@@ -1,0 +1,12 @@
+package com.playkuround.playkuroundserver.infra.email.exception;
+
+import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
+import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;
+
+public class EmailSendFailException extends BusinessException {
+
+    public EmailSendFailException() {
+        super(ErrorCode.EMAIL_SEND_FAIL);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,9 +5,23 @@ server:
 
 spring:
 
-  redis:
-    host: localhost
-    port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: playkuround@gmail.com
+    password: xbccdckhfdcadtba
+    properties:
+      mail:
+        smtp:
+          port: 465
+          auth: true
+          starttls:
+            required: true
+            enable: true
+          socketFactory:
+            class: javax.net.ssl.SSLSocketFactory
+            fallback: false
+            port: 465
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 요약
- `인증 메일 전송 API` 구현
- `인증코드 일치 확인 API` 구현

<br>

## 작업 내용
### 1. 인증 메일 전송
- `요청 바디`로 인증 메일을 보낼 `이메일`을 받음
- 건국대학교 메일인지 검사
- 알파벳 소문자, 대문자, 0~9의 숫자로 이루어진 6자리 인증코드 전송
- `유효시간` 반환(메일 전송 후 5분까지 유효)

### 2. 인증코드 일치 확인
- `쿼리스트링`으로 `이메일`과 `인증코드`를 받음
- 가장 최근에 보낸 인증코드와 일치하는지 검사
- 일치 여부를 `boolean` 으로 반환

<br>

## 기타
- `BaseTimeEntity` 의 `createAt` 변수명을 `createdAt` 으로 변경 (오타  수정)
