### PR TITLE
토큰 만료 관련 로직 수정

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/token/application/RefreshTokenValidator.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/token/application/RefreshTokenValidator.java
@@ -37,11 +37,6 @@ public class RefreshTokenValidator {
         if (!TokenType.REFRESH.name().equals(tokenType)) {
             throw new AuthenticationException(ErrorCode.NOT_REFRESH_TOKEN_TYPE);
         }
-
-        // 엑세스 토큰 만료 시간 검증
-        if (tokenManager.isTokenExpired(refreshToken)) {
-            throw new AuthenticationException(ErrorCode.REFRESH_TOKEN_EXPIRED);
-        }
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
@@ -22,10 +22,9 @@ public enum ErrorCode {
     EMPTY_AUTHORIZATION(401, "A001", "Authorization Header가 빈 값입니다."),
     NOT_BEARER_GRANT_TYPE(401, "A002", "인증 타입이 Bearer 타입이 아닙니다."),
     INVALID_TOKEN(401, "A003", "유효하지 않은 토큰입니다."),
-    ACCESS_TOKEN_EXPIRED(401, "A004", "해당 Access Token은 만료되었습니다."),
+    EXPIRED_TOKEN(401, "A004", "만료된 토큰입니다."),
     NOT_ACCESS_TOKEN_TYPE(401, "A005", "TokenType이 ACCESS가 아닙니다."),
-    REFRESH_TOKEN_EXPIRED(401, "A006", "해당 Refresh Token은 만료되었습니다."),
-    NOT_REFRESH_TOKEN_TYPE(401, "A007", "TokenType이 REFRESH가 아닙니다."),
+    NOT_REFRESH_TOKEN_TYPE(401, "A006", "TokenType이 REFRESH가 아닙니다."),
 
     // Location
     INVALID_LOCATION_LANDMARK(401, "L001", "현재 위치와 랜드마크 위치가 너무 멉니다."),

--- a/src/main/java/com/playkuround/playkuroundserver/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/interceptor/AuthenticationInterceptor.java
@@ -49,11 +49,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             throw new AuthenticationException(ErrorCode.NOT_ACCESS_TOKEN_TYPE);
         }
 
-        // 엑세스 토큰 만료 시간 검증
-        if (tokenManager.isTokenExpired(accessToken)) {
-            throw new AuthenticationException(ErrorCode.ACCESS_TOKEN_EXPIRED);
-        }
-
         return true;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,8 +42,8 @@ logging:
 
 token:
   secret: ENC(P7i3h2tf8pxFcVRjXhOQYT//HTk/u7MgwKpcPHkd6+A=)
-  access-token-expiration-time: 900000  # 15분
-  refresh-token-expiration-time: 1.577e+10 # 6개월
+  access-token-expiration: 900000  # 15분
+  refresh-token-expiration: 2 # 2개월
 
 management:
   endpoint:


### PR DESCRIPTION
## 요약
- `만료된 토큰` 관련 에러 처리 수정
- `리프레시 토큰 유효기간` 수정

<br>

## 작업 내용
- 토큰의 유효성을 검증하는 `validateToken` 메서드의 `catch` 블록에 `ExpiredJwtException` 으로 만료된 토큰 핸들링
- 리프레시 토큰을 `2개월`로 수정하고 `Calendar` 객체를 이용하여 만료 기한 설정