### PR TITLE
LocationUtils 클래스 static 객체 초기화 방식 변경

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/global/util/LocationUtils.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/util/LocationUtils.java
@@ -9,10 +9,10 @@ import java.awt.geom.Path2D;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LocationUtils {
 
-    private static final Path2D.Double polygonKU = new Path2D.Double();
+    private static Path2D.Double polygonKU;
 
-    @PostConstruct
-    private static void initPolygonKU() {
+    static {
+        polygonKU = new Path2D.Double();
         polygonKU.moveTo(37.539563, 127.072121);
         polygonKU.lineTo(37.541176, 127.072846);
         polygonKU.lineTo(37.541647, 127.072494);


### PR DESCRIPTION
## 요약
- `polygonKU` 객체 초기화 방식 변경

<br>

## 작업 내용
- 기존에 `@PostConstruct` 로 초기화를 진행하니 static 변수가 제대로 초기화되지 않아 요청으로 받은 위경도가 건국대학교 내에 위치함에도 잘못된 위치라고 반환
- `static` 블록 내에서 초기화하도록 변경하여 해결
