### PR TITLE
인증 메일 전송 횟수 제한

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/api/AuthEmailApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/api/AuthEmailApi.java
@@ -3,7 +3,7 @@ package com.playkuround.playkuroundserver.domain.auth.email.api;
 import com.playkuround.playkuroundserver.domain.auth.email.application.AuthEmailSendService;
 import com.playkuround.playkuroundserver.domain.auth.email.application.AuthEmailVerifyService;
 import com.playkuround.playkuroundserver.domain.auth.email.dto.AuthEmailSendDto;
-import com.playkuround.playkuroundserver.domain.auth.exception.NotKUEmailException;
+import com.playkuround.playkuroundserver.domain.auth.email.exception.NotKUEmailException;
 import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
 import com.playkuround.playkuroundserver.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailSendService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailSendService.java
@@ -3,12 +3,15 @@ package com.playkuround.playkuroundserver.domain.auth.email.application;
 import com.playkuround.playkuroundserver.domain.auth.email.dao.AuthEmailRepository;
 import com.playkuround.playkuroundserver.domain.auth.email.domain.AuthEmail;
 import com.playkuround.playkuroundserver.domain.auth.email.dto.AuthEmailSendDto;
+import com.playkuround.playkuroundserver.domain.auth.email.exception.SendingLimitExceededException;
 import com.playkuround.playkuroundserver.infra.email.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Random;
 
 @Service
@@ -21,6 +24,9 @@ public class AuthEmailSendService {
     @Transactional
     public AuthEmailSendDto.Response sendAuthEmail(AuthEmailSendDto.Request requestDto) {
         String target = requestDto.getTarget();
+
+        Long sendingCount = validateSendingCount(target);
+
         String title = "[플레이쿠라운드] 회원가입 인증코드입니다.";
         String code = createCode();
         String content = createContent(code);
@@ -31,7 +37,24 @@ public class AuthEmailSendService {
         AuthEmail authEmail = AuthEmail.createAuthEmail(target, code, expiredAt);
         authEmailRepository.save(authEmail);
 
-        return AuthEmailSendDto.Response.of(expiredAt);
+        // 현재 전송 횟수 포함하여 반환
+        return AuthEmailSendDto.Response.of(expiredAt, sendingCount + 1);
+    }
+
+    /**
+     * 하루에 인증 메일 전송은 5회까지 가능합니다.
+     * 5회 초과 시 예외를 던집니다.
+     *
+     * @param target 인증 메일 전송 대상
+     */
+    private Long validateSendingCount(String target) {
+        LocalDateTime today = LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0, 0));
+        Long sendingCount = authEmailRepository.countByTargetAndCreatedAtAfter(target, today);
+        if (sendingCount >= 5) {
+            throw new SendingLimitExceededException();
+        }
+
+        return sendingCount;
     }
 
     private String createContent(String code) {
@@ -63,7 +86,7 @@ public class AuthEmailSendService {
             switch (type) {
                 case 0:
                     // 알파벳 소문자(a~z)
-                    code.append((char) (int)(random.nextInt(26) + 97));
+                    code.append((char) (int) (random.nextInt(26) + 97));
                     break;
                 case 1:
                     // 알파벳 대문자(A~Z)

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailVerifyService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailVerifyService.java
@@ -2,8 +2,8 @@ package com.playkuround.playkuroundserver.domain.auth.email.application;
 
 import com.playkuround.playkuroundserver.domain.auth.email.dao.AuthEmailRepository;
 import com.playkuround.playkuroundserver.domain.auth.email.domain.AuthEmail;
-import com.playkuround.playkuroundserver.domain.auth.exception.AuthCodeExpiredException;
-import com.playkuround.playkuroundserver.domain.auth.exception.AuthEmailNotFoundException;
+import com.playkuround.playkuroundserver.domain.auth.email.exception.AuthCodeExpiredException;
+import com.playkuround.playkuroundserver.domain.auth.email.exception.AuthEmailNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/dao/AuthEmailRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/dao/AuthEmailRepository.java
@@ -3,10 +3,13 @@ package com.playkuround.playkuroundserver.domain.auth.email.dao;
 import com.playkuround.playkuroundserver.domain.auth.email.domain.AuthEmail;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface AuthEmailRepository extends JpaRepository<AuthEmail, Long> {
 
     Optional<AuthEmail> findFirstByTargetOrderByCreatedAtDesc(String target);
+
+    Long countByTargetAndCreatedAtAfter(String target, LocalDateTime localDateTime);
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/dto/AuthEmailSendDto.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/dto/AuthEmailSendDto.java
@@ -29,9 +29,12 @@ public class AuthEmailSendDto {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime expireAt;
 
-        public static Response of(LocalDateTime expireAt) {
+        private Long sendingCount;
+
+        public static Response of(LocalDateTime expireAt, Long sendingCount) {
             return Response.builder()
                     .expireAt(expireAt)
+                    .sendingCount(sendingCount)
                     .build();
         }
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/exception/AuthCodeExpiredException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/exception/AuthCodeExpiredException.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.auth.exception;
+package com.playkuround.playkuroundserver.domain.auth.email.exception;
 
 import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
 import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/exception/AuthEmailNotFoundException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/exception/AuthEmailNotFoundException.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.auth.exception;
+package com.playkuround.playkuroundserver.domain.auth.email.exception;
 
 import com.playkuround.playkuroundserver.global.error.exception.EntityNotFoundException;
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/exception/NotKUEmailException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/exception/NotKUEmailException.java
@@ -1,4 +1,4 @@
-package com.playkuround.playkuroundserver.domain.auth.exception;
+package com.playkuround.playkuroundserver.domain.auth.email.exception;
 
 import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
 import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/exception/SendingLimitExceededException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/exception/SendingLimitExceededException.java
@@ -1,0 +1,12 @@
+package com.playkuround.playkuroundserver.domain.auth.email.exception;
+
+import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
+import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;
+
+public class SendingLimitExceededException extends BusinessException {
+
+    public SendingLimitExceededException() {
+        super(ErrorCode.SENDING_LIMIT_EXCEEDED);
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     NOT_KU_EMAIL(400, "E001", "건국대학교 이메일이 아닙니다."),
     EMAIL_SEND_FAIL(500, "E002", "이메일 전송에 실패하였습니다."),
     EXPIRED_AUTH_CODE(400, "E003", "만료된 코드입니다."),
+    SENDING_LIMIT_EXCEEDED(429, "E004", "인증 메일 전송 횟수를 초과하였습니다."),
 
     ;
 


### PR DESCRIPTION
## 요약
- 인증 메일 전송은 `하루에 5번`까지 가능하도록 제한

<br>

## 작업 내용
- 금일 기준으로 인증 메일 전송 횟수가 5번이 초과되면 예외 던지도록 구현
- 인증 메일 전송 API 호출 시 응답으로 금일 전송 횟수도 추가적으로 반환하도록 구현
