### PR TITLE
회원 삭제 API 추가

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/domain/Adventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/domain/Adventure.java
@@ -6,6 +6,8 @@ import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -20,6 +22,7 @@ public class Adventure extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/domain/Attendance.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/domain/Attendance.java
@@ -8,6 +8,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -30,6 +32,7 @@ public class Attendance extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Builder

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/domain/Badge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/domain/Badge.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -20,6 +22,7 @@ public class Badge extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/domain/Score.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/domain/Score.java
@@ -3,6 +3,8 @@ package com.playkuround.playkuroundserver.domain.score.domain;
 import com.playkuround.playkuroundserver.domain.common.BaseTimeEntity;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -17,6 +19,7 @@ public class Score extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/api/UserApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/api/UserApi.java
@@ -24,25 +24,25 @@ public class UserApi {
     private final UserProfileService userProfileService;
 
     @PostMapping("/register")
-    public ApiResponse<UserRegisterDto.Response> UserRegister(@RequestBody @Valid UserRegisterDto.Request registerRequest) {
+    public ApiResponse<UserRegisterDto.Response> userRegister(@RequestBody @Valid UserRegisterDto.Request registerRequest) {
         UserRegisterDto.Response registerResponse = userRegisterService.registerUser(registerRequest);
         return ApiUtils.success(registerResponse);
     }
 
     @PostMapping("/login")
-    public ApiResponse<UserLoginDto.Response> UserLogin(@UserEmail String userEmail) {
+    public ApiResponse<UserLoginDto.Response> userLogin(@UserEmail String userEmail) {
         UserLoginDto.Response loginResponse = userLoginService.login(userEmail);
         return ApiUtils.success(loginResponse);
     }
 
     @GetMapping
-    public ApiResponse<UserProfileDto.Response> UserProfile(@UserEmail String userEmail) {
+    public ApiResponse<UserProfileDto.Response> userProfile(@UserEmail String userEmail) {
         UserProfileDto.Response profileResponse = userProfileService.getUserProfile(userEmail);
         return ApiUtils.success(profileResponse);
     }
 
     @PostMapping("/logout")
-    public ApiResponse<Void> UserLogout(@UserEmail String userEmail) {
+    public ApiResponse<Void> userLogout(@UserEmail String userEmail) {
         userLogoutService.logout(userEmail);
         return ApiUtils.success(null);
     }
@@ -51,6 +51,12 @@ public class UserApi {
     public ApiResponse<Boolean> nicknameDuplication(@Param("nickname") String nickname) {
         boolean isDuplicate = userProfileService.checkDuplicateNickname(nickname);
         return ApiUtils.success(isDuplicate);
+    }
+
+    @DeleteMapping
+    public ApiResponse<Void> userDelete(@UserEmail String userEmail) {
+        userRegisterService.deleteUser(userEmail);
+        return ApiUtils.success(null);
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserRegisterService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserRegisterService.java
@@ -2,6 +2,7 @@ package com.playkuround.playkuroundserver.domain.user.application;
 
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenManager;
 import com.playkuround.playkuroundserver.domain.auth.token.dto.TokenDto;
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserRegisterService {
 
+    private final UserFindDao userFindDao;
     private final UserRepository userRepository;
     private final UserValidator userValidator;
     private final TokenManager tokenManager;
@@ -32,6 +34,11 @@ public class UserRegisterService {
         user.updateRefreshToken(tokenDto);
 
         return UserRegisterDto.Response.of(tokenDto);
+    }
+
+    public void deleteUser(String userEmail) {
+        User user = userFindDao.findByEmail(userEmail);
+        userRepository.delete(user);
     }
 
 }


### PR DESCRIPTION
## 요약
- `회원 삭제 API` 구현

<br>

## 작업 내용
- 요청: `DELETE` /api/users
- JWT 토큰에서 이메일 추출
- 해당 이메일의 유저 DB에서 삭제
- user 엔티티를 참조하는 엔티티에 `@onDelete` 어노테이션을 이용한 cascade 제약 조건 추가 -> user 삭제 시 user의 score 레코드도 삭제