### PR TITLE
출석 요청 시 중복 출석 방지 로직 추가, 탐험 기록 조회 시 중복 랜드마크 제거 및 api response 수정

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApi.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.List;
 
 @RestController
 @Slf4j
@@ -30,8 +29,8 @@ public class AdventureApi {
     }
 
     @GetMapping
-    public ApiResponse<List<ResponseFindAdventure>> findAdventureByUserEmail(@UserEmail String userEmail) {
-        List<ResponseFindAdventure> adventureByUserEmail = adventureService.findAdventureByUserEmail(userEmail);
+    public ApiResponse<ResponseFindAdventure> findAdventureByUserEmail(@UserEmail String userEmail) {
+        ResponseFindAdventure adventureByUserEmail = adventureService.findAdventureByUserEmail(userEmail);
         return ApiUtils.success(adventureByUserEmail);
 
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -14,7 +14,6 @@ import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.landmark.exception.LandmarkNotFoundException;
 import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
-import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.util.LocationDistanceUtils;
 import lombok.RequiredArgsConstructor;
@@ -97,7 +96,7 @@ public class AdventureService {
     public List<ResponseFindAdventure> findAdventureByUserEmail(String userEmail) {
         User user = userFindDao.findByEmail(userEmail);
 
-        return adventureRepository.findAllByUser(user)
+        return adventureRepository.findDistinctLandmarkIdByUser(user)
                 .stream().map(ResponseFindAdventure::of)
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -3,9 +3,9 @@ package com.playkuround.playkuroundserver.domain.adventure.application;
 import com.playkuround.playkuroundserver.domain.adventure.dao.AdventureRepository;
 import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
 import com.playkuround.playkuroundserver.domain.adventure.dto.AdventureSaveDto;
-import com.playkuround.playkuroundserver.domain.adventure.dto.VisitedUserDto;
 import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseFindAdventure;
 import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseMostVisitedUser;
+import com.playkuround.playkuroundserver.domain.adventure.dto.VisitedUserDto;
 import com.playkuround.playkuroundserver.domain.adventure.exception.InvalidLandmarkLocationException;
 import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
@@ -34,7 +34,6 @@ public class AdventureService {
 
     private final AdventureRepository adventureRepository;
     private final LandmarkRepository landmarkRepository;
-    private final UserRepository userRepository;
     private final BadgeRepository badgeRepository;
     private final UserFindDao userFindDao;
 
@@ -98,9 +97,10 @@ public class AdventureService {
     public List<ResponseFindAdventure> findAdventureByUserEmail(String userEmail) {
         User user = userFindDao.findByEmail(userEmail);
 
-        return adventureRepository.findAllByUser(user).stream()
-                .map(ResponseFindAdventure::of)
+        return adventureRepository.findAllByUser(user)
+                .stream().map(ResponseFindAdventure::of)
                 .collect(Collectors.toList());
+
     }
 
     @Transactional(readOnly = true)
@@ -113,7 +113,7 @@ public class AdventureService {
                 .orElseThrow(() -> new LandmarkNotFoundException(landmarkId));
         User user = userFindDao.findByEmail(userEmail);
 
-        List<VisitedUserDto> visitedInfoes = adventureRepository.customQuery(landmarkId);
+        List<VisitedUserDto> visitedInfoes = adventureRepository.findTop5VisitedUser(landmarkId);
         Integer myVisitedCount = adventureRepository.countAdventureByUserAndLandmark(user, landmark);
         return ResponseMostVisitedUser.of(visitedInfoes, myVisitedCount);
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -93,13 +92,9 @@ public class AdventureService {
     }
 
     @Transactional(readOnly = true)
-    public List<ResponseFindAdventure> findAdventureByUserEmail(String userEmail) {
+    public ResponseFindAdventure findAdventureByUserEmail(String userEmail) {
         User user = userFindDao.findByEmail(userEmail);
-
-        return adventureRepository.findDistinctLandmarkIdByUser(user)
-                .stream().map(ResponseFindAdventure::of)
-                .collect(Collectors.toList());
-
+        return ResponseFindAdventure.of(adventureRepository.findDistinctLandmarkIdByUser(user));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 public interface AdventureRepository extends JpaRepository<Adventure, Long> {
 
     @Query(value = "SELECT DISTINCT a.landmark.id FROM Adventure a WHERE a.user.id=:#{#user.id}")
-    List<Long> findAllByUser(@Param(value = "user") User user);
+    List<Long> findDistinctLandmarkIdByUser(@Param(value = "user") User user);
 
     @Query(value =
             "SELECT " +

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
@@ -11,7 +11,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface AdventureRepository extends JpaRepository<Adventure, Long> {
-    List<Adventure> findAllByUser(User user);
+
+    @Query(value = "SELECT DISTINCT a.landmark.id FROM Adventure a WHERE a.user.id=:#{#user.id}")
+    List<Long> findAllByUser(@Param(value = "user") User user);
 
     @Query(value =
             "SELECT " +
@@ -24,7 +26,7 @@ public interface AdventureRepository extends JpaRepository<Adventure, Long> {
                     "limit 5",
             nativeQuery = true
     )
-    List<VisitedUserDto> customQuery(@Param(value = "landmark") Long landmarkId);
+    List<VisitedUserDto> findTop5VisitedUser(@Param(value = "landmark") Long landmarkId);
 
 
     @Query("SELECT COUNT(*) FROM Adventure a where a.landmark.id>=22 and a.landmark.id<=26")

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
@@ -1,22 +1,21 @@
 package com.playkuround.playkuroundserver.domain.adventure.dto;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
+@AllArgsConstructor
 @NoArgsConstructor
 public class ResponseFindAdventure {
 
-    private Long landmarkId;
+    private List<Long> landmarkIdList;
 
-    public ResponseFindAdventure(Long landmarkId) {
-        this.landmarkId = landmarkId;
-    }
-
-    public static ResponseFindAdventure of(Long landmarkId) {
+    public static ResponseFindAdventure of(List<Long> landmarkId) {
         return new ResponseFindAdventure(landmarkId);
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dto/ResponseFindAdventure.java
@@ -1,13 +1,9 @@
 package com.playkuround.playkuroundserver.domain.adventure.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -15,19 +11,12 @@ import java.time.LocalDateTime;
 public class ResponseFindAdventure {
 
     private Long landmarkId;
-    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
-    private LocalDateTime visitedDateTime;
 
-    @Builder
-    public ResponseFindAdventure(Long landmarkId, LocalDateTime visitedDateTime) {
+    public ResponseFindAdventure(Long landmarkId) {
         this.landmarkId = landmarkId;
-        this.visitedDateTime = visitedDateTime;
     }
 
-    public static ResponseFindAdventure of(Adventure adventure) {
-        return ResponseFindAdventure.builder()
-                .landmarkId(adventure.getLandmark().getId())
-                .visitedDateTime(adventure.getCreatedAt())
-                .build();
+    public static ResponseFindAdventure of(Long landmarkId) {
+        return new ResponseFindAdventure(landmarkId);
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterService.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.attendance.application;
 import com.playkuround.playkuroundserver.domain.attendance.dao.AttendanceRepository;
 import com.playkuround.playkuroundserver.domain.attendance.domain.Attendance;
 import com.playkuround.playkuroundserver.domain.attendance.dto.AttendanceRegisterDto;
+import com.playkuround.playkuroundserver.domain.attendance.exception.DuplicateAttendanceException;
 import com.playkuround.playkuroundserver.domain.attendance.exception.InvalidAttendanceLocationException;
 import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.badge.domain.Badge;
@@ -39,6 +40,9 @@ public class AttendanceRegisterService {
         }
 
         User user = userFindDao.findByEmail(userEmail);
+        if (attendanceRepository.existsByUserAndCreatedAtAfter(user, LocalDate.now().atStartOfDay())) {
+            throw new DuplicateAttendanceException();
+        }
         Attendance attendance = Attendance.createAttendance(latitude, longitude, user);
         attendanceRepository.save(attendance);
         return findNewBadges(user);

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/dao/AttendanceRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/dao/AttendanceRepository.java
@@ -13,4 +13,5 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
     Long countByUserAndCreatedAtAfter(User user, LocalDateTime localDateTime);
 
+    boolean existsByUserAndCreatedAtAfter(User user, LocalDateTime localDateTime);
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/exception/DuplicateAttendanceException.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/exception/DuplicateAttendanceException.java
@@ -1,0 +1,12 @@
+package com.playkuround.playkuroundserver.domain.attendance.exception;
+
+import com.playkuround.playkuroundserver.global.error.exception.BusinessException;
+import com.playkuround.playkuroundserver.global.error.exception.ErrorCode;
+
+public class DuplicateAttendanceException extends BusinessException {
+
+    public DuplicateAttendanceException() {
+        super(ErrorCode.DUPLICATE_ATTENDANCE);
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/error/exception/ErrorCode.java
@@ -40,7 +40,10 @@ public enum ErrorCode {
     SENDING_LIMIT_EXCEEDED(429, "E004", "인증 메일 전송 횟수를 초과하였습니다."),
 
     // Badge
-    INVALID_Badge_TYPE(500, "B001", "올바르지 않은 BadgeType입니다."),
+    INVALID_Badge_TYPE(400, "B001", "올바르지 않은 BadgeType입니다."),
+
+    // Attendance
+    DUPLICATE_ATTENDANCE(400, "AT01", "이미 오늘 출석한 회원입니다."),
 
     ;
 

--- a/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApiTest.java
@@ -198,11 +198,11 @@ class AdventureApiTest {
                         .header("Authorization", "Bearer " + accessToken)
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.response.length()").value(4))
-                .andExpect(jsonPath("$.response.[?(@.landmarkId == '%s')]", 1).exists())
-                .andExpect(jsonPath("$.response.[?(@.landmarkId == '%s')]", 2).exists())
-                .andExpect(jsonPath("$.response.[?(@.landmarkId == '%s')]", 3).exists())
-                .andExpect(jsonPath("$.response.[?(@.landmarkId == '%s')]", 4).exists())
+                .andExpect(jsonPath("$.response.landmarkIdList.length()").value(4))
+                .andExpect(jsonPath("$.response.landmarkIdList", 1).exists())
+                .andExpect(jsonPath("$.response.landmarkIdList", 2).exists())
+                .andExpect(jsonPath("$.response.landmarkIdList", 3).exists())
+                .andExpect(jsonPath("$.response.landmarkIdList", 4).exists())
                 .andDo(print())
                 .andReturn();
     }
@@ -229,11 +229,11 @@ class AdventureApiTest {
                         .header("Authorization", "Bearer " + accessToken)
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.response.length()").value(4))
-                .andExpect(jsonPath("$.response.[?(@.landmarkId == '%s')]", 1).exists())
-                .andExpect(jsonPath("$.response.[?(@.landmarkId == '%s')]", 2).exists())
-                .andExpect(jsonPath("$.response.[?(@.landmarkId == '%s')]", 3).exists())
-                .andExpect(jsonPath("$.response.[?(@.landmarkId == '%s')]", 4).exists())
+                .andExpect(jsonPath("$.response.landmarkIdList.length()").value(4))
+                .andExpect(jsonPath("$.response.landmarkIdList", 1).exists())
+                .andExpect(jsonPath("$.response.landmarkIdList", 2).exists())
+                .andExpect(jsonPath("$.response.landmarkIdList", 3).exists())
+                .andExpect(jsonPath("$.response.landmarkIdList", 4).exists())
                 .andDo(print())
                 .andReturn();
     }


### PR DESCRIPTION
## 요약
- 출석 요청(/api/attendances, post) 시, 중복 출석인 경우 에러 반환(로직 추가)
- 유저의 탐험 기록 조회(/api/adventures, get) 시, 중복 랜드마크 제거 및 방문일 제거

<br>

## 작업 내용
-  탐험한 랜드마크 중 중복 제거를 위해 JPQL 사용(DISTINCT 키워드)

<br>

## 기타

