### PR TITLE
리팩토링

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApi.java
@@ -4,8 +4,9 @@ import com.playkuround.playkuroundserver.domain.adventure.application.AdventureS
 import com.playkuround.playkuroundserver.domain.adventure.dto.AdventureSaveDto;
 import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseFindAdventure;
 import com.playkuround.playkuroundserver.domain.adventure.dto.ResponseMostVisitedUser;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
-import com.playkuround.playkuroundserver.global.resolver.UserEmail;
+import com.playkuround.playkuroundserver.global.resolver.UserEntity;
 import com.playkuround.playkuroundserver.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,22 +24,22 @@ public class AdventureApi {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<AdventureSaveDto.Response> saveAdventure(@UserEmail String userEmail, @RequestBody @Valid AdventureSaveDto.Request dto) {
-        AdventureSaveDto.Response response = adventureService.saveAdventure(userEmail, dto);
+    public ApiResponse<AdventureSaveDto.Response> saveAdventure(@UserEntity User user, @RequestBody @Valid AdventureSaveDto.Request dto) {
+        AdventureSaveDto.Response response = adventureService.saveAdventure(user, dto);
         return ApiUtils.success(response);
     }
 
     @GetMapping
-    public ApiResponse<ResponseFindAdventure> findAdventureByUserEmail(@UserEmail String userEmail) {
-        ResponseFindAdventure adventureByUserEmail = adventureService.findAdventureByUserEmail(userEmail);
+    public ApiResponse<ResponseFindAdventure> findAdventureByUserEmail(@UserEntity User user) {
+        ResponseFindAdventure adventureByUserEmail = adventureService.findAdventureByUserEmail(user);
         return ApiUtils.success(adventureByUserEmail);
 
     }
 
     @GetMapping("/{landmarkId}/most")
-    public ApiResponse<ResponseMostVisitedUser> findMemberMostAdventure(@UserEmail String userEmail,
+    public ApiResponse<ResponseMostVisitedUser> findMemberMostAdventure(@UserEntity User user,
                                                                         @PathVariable Long landmarkId) {
-        ResponseMostVisitedUser memberMostLandmark = adventureService.findMemberMostLandmark(userEmail, landmarkId);
+        ResponseMostVisitedUser memberMostLandmark = adventureService.findMemberMostLandmark(user, landmarkId);
         return ApiUtils.success(memberMostLandmark);
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -14,7 +14,6 @@ import com.playkuround.playkuroundserver.domain.badge.exception.BadgeTypeNotFoun
 import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.landmark.exception.LandmarkNotFoundException;
-import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.util.LocationDistanceUtils;
 import lombok.RequiredArgsConstructor;
@@ -35,11 +34,9 @@ public class AdventureService {
     private final AdventureRepository adventureRepository;
     private final LandmarkRepository landmarkRepository;
     private final BadgeRepository badgeRepository;
-    private final UserFindDao userFindDao;
 
 
-    public AdventureSaveDto.Response saveAdventure(String userEmail, AdventureSaveDto.Request dto) {
-        User user = userFindDao.findByEmail(userEmail);
+    public AdventureSaveDto.Response saveAdventure(User user, AdventureSaveDto.Request dto) {
         Landmark landmark = landmarkRepository.findById(dto.getLandmarkId())
                 .orElseThrow(() -> new LandmarkNotFoundException(dto.getLandmarkId()));
         validateLocation(landmark, dto.getLatitude(), dto.getLongitude());
@@ -98,19 +95,16 @@ public class AdventureService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseFindAdventure findAdventureByUserEmail(String userEmail) {
-        User user = userFindDao.findByEmail(userEmail);
+    public ResponseFindAdventure findAdventureByUserEmail(User user) {
         return ResponseFindAdventure.of(adventureRepository.findDistinctLandmarkIdByUser(user));
     }
 
     @Transactional(readOnly = true)
-    public ResponseMostVisitedUser findMemberMostLandmark(String userEmail, Long landmarkId) {
+    public ResponseMostVisitedUser findMemberMostLandmark(User user, Long landmarkId) {
         /*
          * 해당 랜드마크에 가장 많이 방문한 회원
          * 횟수가 같다면 방문한지 오래된 회원 -> 정책 논의 필요
          */
-        User user = userFindDao.findByEmail(userEmail);
-
         List<VisitedUserDto> visitedInfoList = adventureRepository.findVisitedUsersRank(landmarkId);
         return ResponseMostVisitedUser.of(visitedInfoList, user.getId());
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/api/AttendanceApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/api/AttendanceApi.java
@@ -4,8 +4,9 @@ import com.playkuround.playkuroundserver.domain.attendance.application.Attendanc
 import com.playkuround.playkuroundserver.domain.attendance.application.AttendanceSearchService;
 import com.playkuround.playkuroundserver.domain.attendance.dto.AttendanceRegisterDto;
 import com.playkuround.playkuroundserver.domain.attendance.dto.AttendanceSearchDto;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
-import com.playkuround.playkuroundserver.global.resolver.UserEmail;
+import com.playkuround.playkuroundserver.global.resolver.UserEntity;
 import com.playkuround.playkuroundserver.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -23,14 +24,14 @@ public class AttendanceApi {
     private final AttendanceRegisterService attendanceRegisterService;
 
     @PostMapping
-    public ApiResponse<AttendanceRegisterDto.Response> attendanceRegister(@UserEmail String userEmail, @Valid @RequestBody AttendanceRegisterDto.Request registerRequest) {
-        AttendanceRegisterDto.Response response = attendanceRegisterService.registerAttendance(userEmail, registerRequest);
+    public ApiResponse<AttendanceRegisterDto.Response> attendanceRegister(@UserEntity User user, @Valid @RequestBody AttendanceRegisterDto.Request registerRequest) {
+        AttendanceRegisterDto.Response response = attendanceRegisterService.registerAttendance(user, registerRequest);
         return ApiUtils.success(response);
     }
 
     @GetMapping
-    public ApiResponse<AttendanceSearchDto.Response> attendanceSearch(@UserEmail String userEmail) {
-        List<LocalDateTime> attendances = attendanceSearchService.findByUserMonthLong(userEmail);
+    public ApiResponse<AttendanceSearchDto.Response> attendanceSearch(@UserEntity User user) {
+        List<LocalDateTime> attendances = attendanceSearchService.findByUserMonthLong(user);
         return ApiUtils.success(AttendanceSearchDto.Response.of(attendances));
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchService.java
@@ -3,7 +3,6 @@ package com.playkuround.playkuroundserver.domain.attendance.application;
 import com.playkuround.playkuroundserver.domain.attendance.dao.AttendanceRepository;
 import com.playkuround.playkuroundserver.domain.attendance.domain.Attendance;
 import com.playkuround.playkuroundserver.domain.common.BaseTimeEntity;
-import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,11 +17,9 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class AttendanceSearchService {
 
-    private final UserFindDao userFindDao;
     private final AttendanceRepository attendanceRepository;
 
-    public List<LocalDateTime> findByUserMonthLong(String userEmail) {
-        User user = userFindDao.findByEmail(userEmail);
+    public List<LocalDateTime> findByUserMonthLong(User user) {
         List<Attendance> attendances = attendanceRepository.findByUserAndCreatedAtAfter(user, LocalDateTime.now().minusMonths(1));
         return attendances.stream()
                 .map(BaseTimeEntity::getCreatedAt)

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/domain/Attendance.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/domain/Attendance.java
@@ -42,12 +42,4 @@ public class Attendance extends BaseTimeEntity {
         this.user = user;
     }
 
-    public static Attendance createAttendance(Double latitude, Double longitude, User user) {
-        return Attendance.builder()
-                .latitude(latitude)
-                .longitude(longitude)
-                .user(user)
-                .build();
-    }
-
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/dto/AttendanceRegisterDto.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/dto/AttendanceRegisterDto.java
@@ -1,7 +1,9 @@
 package com.playkuround.playkuroundserver.domain.attendance.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.playkuround.playkuroundserver.domain.attendance.domain.Attendance;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.validation.Latitude;
 import com.playkuround.playkuroundserver.global.validation.Longitude;
 import lombok.AllArgsConstructor;
@@ -24,6 +26,14 @@ public class AttendanceRegisterDto {
 
         @Longitude
         private Double longitude;
+
+        public Attendance toEntity(User user) {
+            return Attendance.builder()
+                    .latitude(latitude)
+                    .longitude(longitude)
+                    .user(user)
+                    .build();
+        }
     }
 
     @Getter

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailVerifyService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailVerifyService.java
@@ -7,6 +7,7 @@ import com.playkuround.playkuroundserver.domain.auth.email.exception.AuthCodeExp
 import com.playkuround.playkuroundserver.domain.auth.email.exception.AuthEmailNotFoundException;
 import com.playkuround.playkuroundserver.domain.auth.email.exception.NotMatchAuthCodeException;
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenManager;
+import com.playkuround.playkuroundserver.domain.auth.token.application.TokenService;
 import com.playkuround.playkuroundserver.domain.auth.token.dto.TokenDto;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
@@ -25,6 +26,7 @@ public class AuthEmailVerifyService {
     private final AuthEmailRepository authEmailRepository;
     private final UserRepository userRepository;
     private final TokenManager tokenManager;
+    private final TokenService tokenService;
 
     public AuthVerifyEmailDto.Response verifyAuthEmail(String code, String email) {
         AuthEmail authEmail = authEmailRepository.findFirstByTargetOrderByCreatedAtDesc(email)
@@ -42,7 +44,7 @@ public class AuthEmailVerifyService {
         if (optionalUser.isPresent()) {
             User user = optionalUser.get();
             TokenDto tokenDto = tokenManager.createTokenDto(user.getEmail());
-            user.updateRefreshToken(tokenDto);
+            tokenService.updateRefreshToken(user);
             return AuthVerifyEmailDto.Response.of(tokenDto);
         }
         else return new AuthVerifyEmailDto.Response();

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/token/application/TokenService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/token/application/TokenService.java
@@ -1,16 +1,17 @@
 package com.playkuround.playkuroundserver.domain.auth.token.application;
 
+import com.playkuround.playkuroundserver.domain.auth.token.dao.RefreshTokenFindDao;
 import com.playkuround.playkuroundserver.domain.auth.token.dao.RefreshTokenRepository;
 import com.playkuround.playkuroundserver.domain.auth.token.domain.RefreshToken;
 import com.playkuround.playkuroundserver.domain.auth.token.dto.TokenDto;
 import com.playkuround.playkuroundserver.domain.auth.token.exception.InvalidTokenException;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class TokenService {
 
     private final TokenManager tokenManager;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenFindDao refreshTokenFindDao;
 
     public TokenDto.AccessTokenDto reissueAccessToken(String refreshTokenDto) {
         RefreshToken refreshToken = refreshTokenRepository.findById(refreshTokenDto)
@@ -35,9 +37,9 @@ public class TokenService {
     }
 
     @Transactional
-    public void registerRefreshToken(String userEmail, String refreshTokenDto) {
+    public void registerRefreshToken(User user, String refreshTokenDto) {
         RefreshToken refreshToken = RefreshToken.of(
-                userEmail,
+                user.getEmail(),
                 refreshTokenDto,
                 Integer.parseInt(refreshTokenTimeToLive)
         );
@@ -45,9 +47,15 @@ public class TokenService {
     }
 
     @Transactional
-    public void deleteRefreshTokenByUserEmail(String userEmail) {
-        List<RefreshToken> refreshTokens = refreshTokenRepository.findAllByUserEmail(userEmail);
-        refreshTokens.forEach(refreshToken -> refreshTokenRepository.deleteById(refreshToken.getRefreshToken()));
+    public void updateRefreshToken(User user) {
+        RefreshToken refreshToken = refreshTokenFindDao.findByUser(user);
+        refreshToken.updateTimeToLive(Integer.parseInt(refreshTokenTimeToLive));
+    }
+
+    @Transactional
+    public void deleteRefreshTokenByUser(User user) {
+        RefreshToken refreshToken = refreshTokenFindDao.findByUser(user);
+        refreshTokenRepository.delete(refreshToken);
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/token/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/token/dao/RefreshTokenRepository.java
@@ -1,12 +1,16 @@
 package com.playkuround.playkuroundserver.domain.auth.token.dao;
 
 import com.playkuround.playkuroundserver.domain.auth.token.domain.RefreshToken;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 
     List<RefreshToken> findAllByUserEmail(String userEmail);
+
+    Optional<RefreshToken> findByUser(User user);
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/token/domain/RefreshToken.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/token/domain/RefreshToken.java
@@ -21,12 +21,16 @@ public class RefreshToken {
     private final String userEmail;
 
     @TimeToLive(unit = TimeUnit.DAYS)
-    private final Integer timeToLive;
+    private Integer timeToLive;
 
     @Builder
     public RefreshToken(String userEmail, String refreshToken, Integer timeToLive) {
         this.userEmail = userEmail;
         this.refreshToken = refreshToken;
+        this.timeToLive = timeToLive;
+    }
+
+    public void updateTimeToLive(Integer timeToLive) {
         this.timeToLive = timeToLive;
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/api/BadgeApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/api/BadgeApi.java
@@ -3,8 +3,9 @@ package com.playkuround.playkuroundserver.domain.badge.api;
 import com.playkuround.playkuroundserver.domain.badge.application.BadgeService;
 import com.playkuround.playkuroundserver.domain.badge.dto.BadgeFindDto;
 import com.playkuround.playkuroundserver.domain.badge.dto.BadgeSaveDto;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
-import com.playkuround.playkuroundserver.global.resolver.UserEmail;
+import com.playkuround.playkuroundserver.global.resolver.UserEntity;
 import com.playkuround.playkuroundserver.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,16 +22,16 @@ public class BadgeApi {
     private final BadgeService badgeService;
 
     @GetMapping
-    public ApiResponse<?> findBadge(@UserEmail String userEmail) {
-        List<BadgeFindDto> badges = badgeService.findBadgeByEmail(userEmail);
+    public ApiResponse<?> findBadge(@UserEntity User user) {
+        List<BadgeFindDto> badges = badgeService.findBadgeByEmail(user);
         return ApiUtils.success(badges);
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<?> saveBadge(@UserEmail String userEmail,
+    public ApiResponse<?> saveBadge(@UserEntity User user,
                                     @RequestBody @Valid BadgeSaveDto badgeSaveDto) {
-        badgeService.registerBadge(userEmail, badgeSaveDto.getBadgeType());
+        badgeService.registerBadge(user, badgeSaveDto.getBadgeType());
         return ApiUtils.success(null);
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeService.java
@@ -4,7 +4,6 @@ import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.badge.domain.Badge;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.badge.dto.BadgeFindDto;
-import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,17 +17,14 @@ import java.util.stream.Collectors;
 @Transactional
 public class BadgeService {
 
-    private final UserFindDao userFindDao;
     private final BadgeRepository badgeRepository;
 
-    public void registerBadge(String userEmail, String badgeType) {
-        User user = userFindDao.findByEmail(userEmail);
+    public void registerBadge(User user, String badgeType) {
         Badge badge = Badge.createBadge(user, BadgeType.valueOf(badgeType));
         badgeRepository.save(badge);
     }
 
-    public List<BadgeFindDto> findBadgeByEmail(String userEmail) {
-        User user = userFindDao.findByEmail(userEmail);
+    public List<BadgeFindDto> findBadgeByEmail(User user) {
         return badgeRepository.findByUser(user).stream()
                 .map(BadgeFindDto::of)
                 .collect(Collectors.toList());

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/api/ScoreApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/api/ScoreApi.java
@@ -1,10 +1,11 @@
 package com.playkuround.playkuroundserver.domain.score.api;
 
 import com.playkuround.playkuroundserver.domain.score.application.ScoreService;
-import com.playkuround.playkuroundserver.domain.score.dto.ScoreRegisterDto;
 import com.playkuround.playkuroundserver.domain.score.dto.ScoreRankingDto;
+import com.playkuround.playkuroundserver.domain.score.dto.ScoreRegisterDto;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
-import com.playkuround.playkuroundserver.global.resolver.UserEmail;
+import com.playkuround.playkuroundserver.global.resolver.UserEntity;
 import com.playkuround.playkuroundserver.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,8 +26,8 @@ public class ScoreApi {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<Void> saveAdventure(@UserEmail String userEmail, @RequestBody @Valid ScoreRegisterDto saveScore) {
-        scoreService.saveScore(userEmail, saveScore);
+    public ApiResponse<Void> saveAdventure(@UserEntity User user, @RequestBody @Valid ScoreRegisterDto saveScore) {
+        scoreService.saveScore(user, saveScore);
         return ApiUtils.success(null);
     }
 
@@ -36,8 +37,8 @@ public class ScoreApi {
     }
 
     @GetMapping("/rankings")
-    public ApiResponse<ScoreRankingDto> scoreGetRanking(@UserEmail String userEmail) {
-        return ApiUtils.success(scoreService.getRanking(userEmail));
+    public ApiResponse<ScoreRankingDto> scoreGetRanking(@UserEntity User user) {
+        return ApiUtils.success(scoreService.getRanking(user));
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
@@ -1,6 +1,8 @@
 package com.playkuround.playkuroundserver.domain.score.application;
 
 import com.playkuround.playkuroundserver.domain.score.dao.ScoreRepository;
+import com.playkuround.playkuroundserver.domain.score.domain.Score;
+import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
 import com.playkuround.playkuroundserver.domain.score.dto.ScoreRankingDto;
 import com.playkuround.playkuroundserver.domain.score.dto.ScoreRegisterDto;
 import com.playkuround.playkuroundserver.domain.score.exception.ScoreNotFoundException;
@@ -24,6 +26,14 @@ public class ScoreService {
     public void saveScore(User user, ScoreRegisterDto saveScore) {
         // TODO 검증의 범위는 어디까지? 예를 들면, 진짜로 유저가 탐험을 했는지 안했는지 확인까지 해야하는가?
         scoreRepository.save(saveScore.toEntity(user));
+    }
+
+    public void initScore(User user) {
+        Score score = Score.builder()
+                .user(user)
+                .scoreType(ScoreType.INIT)
+                .build();
+        scoreRepository.save(score);
     }
 
     public List<ScoreRankingDto> getTop100() {

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/ScoreService.java
@@ -1,10 +1,9 @@
 package com.playkuround.playkuroundserver.domain.score.application;
 
 import com.playkuround.playkuroundserver.domain.score.dao.ScoreRepository;
-import com.playkuround.playkuroundserver.domain.score.dto.ScoreRegisterDto;
 import com.playkuround.playkuroundserver.domain.score.dto.ScoreRankingDto;
+import com.playkuround.playkuroundserver.domain.score.dto.ScoreRegisterDto;
 import com.playkuround.playkuroundserver.domain.score.exception.ScoreNotFoundException;
-import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,12 +19,10 @@ import java.util.List;
 public class ScoreService {
 
     private final ScoreRepository scoreRepository;
-    private final UserFindDao userFindDao;
 
     @Transactional
-    public void saveScore(String userEmail, ScoreRegisterDto saveScore) {
+    public void saveScore(User user, ScoreRegisterDto saveScore) {
         // TODO 검증의 범위는 어디까지? 예를 들면, 진짜로 유저가 탐험을 했는지 안했는지 확인까지 해야하는가?
-        User user = userFindDao.findByEmail(userEmail);
         scoreRepository.save(saveScore.toEntity(user));
     }
 
@@ -33,10 +30,9 @@ public class ScoreService {
         return scoreRepository.findTop100();
     }
 
-    public ScoreRankingDto getRanking(String userEmail) {
-        User user = userFindDao.findByEmail(userEmail);
+    public ScoreRankingDto getRanking(User user) {
         return scoreRepository.findRankingByUser(user.getId())
-                .orElseThrow(() -> new ScoreNotFoundException(userEmail));
+                .orElseThrow(() -> new ScoreNotFoundException(user.getEmail()));
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/domain/ScoreType.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/domain/ScoreType.java
@@ -1,7 +1,10 @@
 package com.playkuround.playkuroundserver.domain.score.domain;
 
 public enum ScoreType {
-    ATTENDANCE(1), ADVENTURE(5), EXTRA_ADVENTURE(1);
+    INIT(0),
+    ATTENDANCE(1),
+    ADVENTURE(5),
+    EXTRA_ADVENTURE(1);
 
     private final int point;
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/api/UserApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/api/UserApi.java
@@ -1,11 +1,15 @@
 package com.playkuround.playkuroundserver.domain.user.api;
 
-import com.playkuround.playkuroundserver.domain.user.application.*;
+import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
+import com.playkuround.playkuroundserver.domain.user.application.UserLogoutService;
+import com.playkuround.playkuroundserver.domain.user.application.UserProfileService;
+import com.playkuround.playkuroundserver.domain.user.application.UserRegisterService;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserLoginDto;
 import com.playkuround.playkuroundserver.domain.user.dto.UserProfileDto;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
 import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
-import com.playkuround.playkuroundserver.global.resolver.UserEmail;
+import com.playkuround.playkuroundserver.global.resolver.UserEntity;
 import com.playkuround.playkuroundserver.global.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.repository.query.Param;
@@ -30,20 +34,20 @@ public class UserApi {
     }
 
     @PostMapping("/login")
-    public ApiResponse<UserLoginDto.Response> userLogin(@UserEmail String userEmail) {
-        UserLoginDto.Response loginResponse = userLoginService.login(userEmail);
+    public ApiResponse<UserLoginDto.Response> userLogin(@UserEntity User user) {
+        UserLoginDto.Response loginResponse = userLoginService.login(user);
         return ApiUtils.success(loginResponse);
     }
 
     @GetMapping
-    public ApiResponse<UserProfileDto.Response> userProfile(@UserEmail String userEmail) {
-        UserProfileDto.Response profileResponse = userProfileService.getUserProfile(userEmail);
+    public ApiResponse<UserProfileDto.Response> userProfile(@UserEntity User user) {
+        UserProfileDto.Response profileResponse = userProfileService.getUserProfile(user);
         return ApiUtils.success(profileResponse);
     }
 
     @PostMapping("/logout")
-    public ApiResponse<Void> userLogout(@UserEmail String userEmail) {
-        userLogoutService.logout(userEmail);
+    public ApiResponse<Void> userLogout(@UserEntity User user) {
+        userLogoutService.logout(user);
         return ApiUtils.success(null);
     }
 
@@ -54,8 +58,8 @@ public class UserApi {
     }
 
     @DeleteMapping
-    public ApiResponse<Void> userDelete(@UserEmail String userEmail) {
-        userRegisterService.deleteUser(userEmail);
+    public ApiResponse<Void> userDelete(@UserEntity User user) {
+        userRegisterService.deleteUser(user);
         return ApiUtils.success(null);
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserLoginService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserLoginService.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.user.application;
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenManager;
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenService;
 import com.playkuround.playkuroundserver.domain.auth.token.dto.TokenDto;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserLoginDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,14 +18,11 @@ public class UserLoginService {
     private final TokenManager tokenManager;
     private final TokenService tokenService;
 
-    public UserLoginDto.Response login(String userEmail) {
-        // 가입된 유저인지 확인
-        userValidator.validateRegisteredUser(userEmail);
-
+    public UserLoginDto.Response login(User user) {
         // 응답으로 반환할 토큰 생성
         // 리프레시 토큰 레디스에 저장
-        TokenDto tokenDto = tokenManager.createTokenDto(userEmail);
-        tokenService.registerRefreshToken(userEmail, tokenDto.getRefreshToken());
+        TokenDto tokenDto = tokenManager.createTokenDto(user.getEmail());
+        tokenService.registerRefreshToken(user, tokenDto.getRefreshToken());
 
         return UserLoginDto.Response.of(tokenDto);
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserLogoutService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserLogoutService.java
@@ -1,7 +1,7 @@
 package com.playkuround.playkuroundserver.domain.user.application;
 
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenService;
-import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,11 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserLogoutService {
 
-    private final UserFindDao userFindDao;
     private final TokenService tokenService;
 
-    public void logout(String userEmail) {
-        tokenService.deleteRefreshTokenByUserEmail(userEmail);
+    public void logout(User user) {
+        tokenService.deleteRefreshTokenByUser(user);
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserProfileService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserProfileService.java
@@ -1,6 +1,5 @@
 package com.playkuround.playkuroundserver.domain.user.application;
 
-import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserProfileDto;
@@ -13,11 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserProfileService {
 
-    private final UserFindDao userFindDao;
     private final UserRepository userRepository;
 
-    public UserProfileDto.Response getUserProfile(String email) {
-        User user = userFindDao.findByEmail(email);
+    public UserProfileDto.Response getUserProfile(User user) {
         return UserProfileDto.Response.of(user);
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserRegisterService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserRegisterService.java
@@ -3,7 +3,6 @@ package com.playkuround.playkuroundserver.domain.user.application;
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenManager;
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenService;
 import com.playkuround.playkuroundserver.domain.auth.token.dto.TokenDto;
-import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserRegisterService {
 
-    private final UserFindDao userFindDao;
     private final UserRepository userRepository;
     private final UserValidator userValidator;
     private final TokenManager tokenManager;
@@ -38,8 +36,7 @@ public class UserRegisterService {
         return UserRegisterDto.Response.of(tokenDto);
     }
 
-    public void deleteUser(String userEmail) {
-        User user = userFindDao.findByEmail(userEmail);
+    public void deleteUser(User user) {
         userRepository.delete(user);
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserRegisterService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserRegisterService.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.user.application;
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenManager;
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenService;
 import com.playkuround.playkuroundserver.domain.auth.token.dto.TokenDto;
+import com.playkuround.playkuroundserver.domain.score.application.ScoreService;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
@@ -19,6 +20,7 @@ public class UserRegisterService {
     private final UserValidator userValidator;
     private final TokenManager tokenManager;
     private final TokenService tokenService;
+    private final ScoreService scoreService;
 
     public UserRegisterDto.Response registerUser(UserRegisterDto.Request registerRequest) {
         // 중복 검사
@@ -32,6 +34,8 @@ public class UserRegisterService {
         // 리프레시 토큰 레디스에 저장
         TokenDto tokenDto = tokenManager.createTokenDto(user.getEmail());
         tokenService.registerRefreshToken(user, tokenDto.getRefreshToken());
+
+        scoreService.initScore(user);
 
         return UserRegisterDto.Response.of(tokenDto);
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserRegisterService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserRegisterService.java
@@ -31,7 +31,7 @@ public class UserRegisterService {
         // 응답으로 반환할 토큰 생성
         // 리프레시 토큰 레디스에 저장
         TokenDto tokenDto = tokenManager.createTokenDto(user.getEmail());
-        tokenService.registerRefreshToken(user.getEmail(), tokenDto.getRefreshToken());
+        tokenService.registerRefreshToken(user, tokenDto.getRefreshToken());
 
         return UserRegisterDto.Response.of(tokenDto);
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserValidator.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserValidator.java
@@ -3,7 +3,6 @@ package com.playkuround.playkuroundserver.domain.user.application;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.exception.UserEmailDuplicationException;
 import com.playkuround.playkuroundserver.domain.user.exception.UserNicknameDuplicationException;
-import com.playkuround.playkuroundserver.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,12 +23,6 @@ public class UserValidator {
     public void validateDuplicateNickName(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
             throw new UserNicknameDuplicationException();
-        }
-    }
-
-    public void validateRegisteredUser(String email) {
-        if (!userRepository.existsByEmail(email)) {
-            throw new UserNotFoundException(email);
         }
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/global/common/response/ApiResponse.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/common/response/ApiResponse.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
 @AllArgsConstructor
 public class ApiResponse<T> {
 

--- a/src/main/java/com/playkuround/playkuroundserver/global/resolver/UserEmailArgumentResolver.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/resolver/UserEmailArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.playkuround.playkuroundserver.global.resolver;
 
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenManager;
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -11,19 +13,24 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
 
 @Component
 @RequiredArgsConstructor
 public class UserEmailArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final TokenManager tokenManager;
+    private final UserFindDao userFindDao;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        boolean hasEmailAnnotation = parameter.hasParameterAnnotation(UserEmail.class);
-        boolean hasString = String.class.isAssignableFrom(parameter.getParameterType());
+        boolean hasAnnotation = parameter.hasParameterAnnotation(UserEntity.class);
+        boolean isUserClass = Objects.equals(
+                User.class,
+                parameter.getParameterType()
+                );
 
-        return hasEmailAnnotation && hasString;
+        return hasAnnotation && isUserClass;
     }
 
     @Override
@@ -32,7 +39,7 @@ public class UserEmailArgumentResolver implements HandlerMethodArgumentResolver 
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
         token = token.split(" ")[1];
         String userEmail = tokenManager.getUserEmail(token);
-        return userEmail;
+        return userFindDao.findByEmail(userEmail);
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/global/resolver/UserEntity.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/resolver/UserEntity.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface UserEmail {
+public @interface UserEntity {
 }

--- a/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApiTest.java
@@ -9,6 +9,7 @@ import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
 import com.playkuround.playkuroundserver.domain.user.application.UserRegisterService;
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
@@ -49,6 +50,9 @@ class AdventureApiTest {
     private UserRepository userRepository;
 
     @Autowired
+    private UserFindDao userFindDao;
+
+    @Autowired
     private BadgeRepository badgeRepository;
 
     @Autowired
@@ -73,7 +77,8 @@ class AdventureApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User savedUser = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(savedUser).getAccessToken();
 
         AdventureSaveDto.Request adventureSaveDto = new AdventureSaveDto.Request(1L, 37.539927, 127.073006);
         String content = objectMapper.writeValueAsString(adventureSaveDto);
@@ -104,12 +109,13 @@ class AdventureApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(2L, 37.540158, 127.073463));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(3L, 37.539314, 127.074319));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(5L, 37.541211, 127.073883));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(2L, 37.540158, 127.073463));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(3L, 37.539314, 127.074319));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(5L, 37.541211, 127.073883));
 
         AdventureSaveDto.Request adventureSaveDto = new AdventureSaveDto.Request(1L, 37.539927, 127.073006);
         String content = objectMapper.writeValueAsString(adventureSaveDto);
@@ -132,12 +138,13 @@ class AdventureApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(22L, 37.541755, 127.078681));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(23L, 37.542101, 127.079445));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(24L, 37.541135, 127.079324));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(25L, 37.540884, 127.079518));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(22L, 37.541755, 127.078681));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(23L, 37.542101, 127.079445));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(24L, 37.541135, 127.079324));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(25L, 37.540884, 127.079518));
 
         AdventureSaveDto.Request adventureSaveDto = new AdventureSaveDto.Request(26L, 37.541250, 127.080375);
         String content = objectMapper.writeValueAsString(adventureSaveDto);
@@ -162,9 +169,10 @@ class AdventureApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(8L, 37.542775, 127.073131));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(8L, 37.542775, 127.073131));
 
         AdventureSaveDto.Request adventureSaveDto = new AdventureSaveDto.Request(28L, 37.542095, 127.080905);
         String content = objectMapper.writeValueAsString(adventureSaveDto);
@@ -187,12 +195,13 @@ class AdventureApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(2L, 37.540158, 127.073463));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(3L, 37.539314, 127.074319));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(2L, 37.540158, 127.073463));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(3L, 37.539314, 127.074319));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
 
         // expected
         mockMvc.perform(get("/api/adventures")
@@ -215,10 +224,11 @@ class AdventureApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User SavedUser = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(SavedUser).getAccessToken();
 
         AdventureSaveDto.Request adventureSaveDto = new AdventureSaveDto.Request(1L, 37.539927, 127.073006);
-        adventureService.saveAdventure(userEmail, adventureSaveDto);
+        adventureService.saveAdventure(SavedUser, adventureSaveDto);
         String content = objectMapper.writeValueAsString(adventureSaveDto);
 
         // expected
@@ -250,15 +260,16 @@ class AdventureApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(2L, 37.540158, 127.073463));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(3L, 37.539314, 127.074319));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(3L, 37.539314, 127.074319));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
-        adventureService.saveAdventure(userEmail, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(2L, 37.540158, 127.073463));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(3L, 37.539314, 127.074319));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(3L, 37.539314, 127.074319));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
+        adventureService.saveAdventure(user, new AdventureSaveDto.Request(4L, 37.540099, 127.073976));
 
         // expected
         mockMvc.perform(get("/api/adventures")
@@ -284,7 +295,9 @@ class AdventureApiTest {
         String user2Email = "test2@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(user1Email, "tester1", "컴퓨터공학부"));
         userRegisterService.registerUser(new UserRegisterDto.Request(user2Email, "tester2", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(user1Email).getAccessToken();
+        User user1 = userFindDao.findByEmail(user1Email);
+        User user2 = userFindDao.findByEmail(user2Email);
+        String accessToken = userLoginService.login(user1).getAccessToken();
 
         // expected
         // 1. 해당 위치에 한 명도 방문한 적이 없는 경우
@@ -296,9 +309,9 @@ class AdventureApiTest {
                 .andDo(print());
 
         // 2. 한 번이라도 더 방문한 회원 응답
-        adventureService.saveAdventure(user1Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(user1Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(user2Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user1, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user1, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user2, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
         mockMvc.perform(get("/api/adventures/1/most")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + accessToken)
@@ -314,7 +327,7 @@ class AdventureApiTest {
                 .andDo(print());
 
         // 3. 방문 횟수가 같다면, 방문한지 오래된 회원 응답
-        adventureService.saveAdventure(user2Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user2, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
         mockMvc.perform(get("/api/adventures/1/most")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + accessToken)
@@ -330,7 +343,7 @@ class AdventureApiTest {
                 .andDo(print());
 
         // 4. 한 번이라도 더 방문한 회원 응답
-        adventureService.saveAdventure(user2Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user2, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
         mockMvc.perform(get("/api/adventures/1/most")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + accessToken)
@@ -363,13 +376,20 @@ class AdventureApiTest {
         userRegisterService.registerUser(new UserRegisterDto.Request(user4Email, "tester4", "컴퓨터공학부"));
         userRegisterService.registerUser(new UserRegisterDto.Request(user5Email, "tester5", "컴퓨터공학부"));
         userRegisterService.registerUser(new UserRegisterDto.Request(user6Email, "tester6", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(user1Email).getAccessToken();
+        User user1 = userFindDao.findByEmail(user1Email);
+        User user2 = userFindDao.findByEmail(user2Email);
+        User user3 = userFindDao.findByEmail(user3Email);
+        User user4 = userFindDao.findByEmail(user4Email);
+        User user5 = userFindDao.findByEmail(user5Email);
+        User user6 = userFindDao.findByEmail(user6Email);
+
+        String accessToken = userLoginService.login(user1).getAccessToken();
 
         // expected
         // 1. 3명이 한번씩 방문
-        adventureService.saveAdventure(user2Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(user3Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(user4Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user2, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user3, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user4, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
         mockMvc.perform(get("/api/adventures/1/most")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + accessToken)
@@ -385,9 +405,9 @@ class AdventureApiTest {
                 .andDo(print());
 
         // 2. 6명이 한번씩 방문
-        adventureService.saveAdventure(user1Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(user5Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(user6Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user1, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user5, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user6, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
         mockMvc.perform(get("/api/adventures/1/most")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + accessToken)
@@ -409,8 +429,8 @@ class AdventureApiTest {
                 .andDo(print());
 
         // 3. 2명이 한번씩 더 방문
-        adventureService.saveAdventure(user5Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
-        adventureService.saveAdventure(user6Email, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user5, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
+        adventureService.saveAdventure(user6, new AdventureSaveDto.Request(1L, 37.539927, 127.073006));
         mockMvc.perform(get("/api/adventures/1/most")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + accessToken)

--- a/src/test/java/com/playkuround/playkuroundserver/domain/attendance/api/AttendanceApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/attendance/api/AttendanceApiTest.java
@@ -7,7 +7,9 @@ import com.playkuround.playkuroundserver.domain.attendance.dto.AttendanceRegiste
 import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
 import com.playkuround.playkuroundserver.domain.user.application.UserRegisterService;
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +41,9 @@ class AttendanceApiTest {
     private UserRepository userRepository;
 
     @Autowired
+    private UserFindDao userFindDao;
+
+    @Autowired
     private AttendanceRepository attendanceRepository;
 
     @Autowired
@@ -66,7 +71,8 @@ class AttendanceApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
         AttendanceRegisterDto.Request request = new AttendanceRegisterDto.Request(37.539927, 127.073006);
         String content = objectMapper.writeValueAsString(request);
@@ -88,11 +94,12 @@ class AttendanceApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
         // 오늘 출석 완료
         AttendanceRegisterDto.Request request = new AttendanceRegisterDto.Request(37.539927, 127.073006);
-        attendanceRegisterService.registerAttendance(userEmail, request);
+        attendanceRegisterService.registerAttendance(user, request);
 
         String content = objectMapper.writeValueAsString(request);
         // expected - 한번 더 출석

--- a/src/test/java/com/playkuround/playkuroundserver/domain/badge/api/BadgeApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/badge/api/BadgeApiTest.java
@@ -8,6 +8,7 @@ import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.badge.dto.BadgeSaveDto;
 import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
 import com.playkuround.playkuroundserver.domain.user.application.UserRegisterService;
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
@@ -51,6 +52,9 @@ class BadgeApiTest {
     private UserRepository userRepository;
 
     @Autowired
+    private UserFindDao userFindDao;
+
+    @Autowired
     private BadgeRepository badgeRepository;
 
     @Autowired
@@ -67,7 +71,8 @@ class BadgeApiTest {
     void findBadgeZero() throws Exception {
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
         mockMvc.perform(get("/api/badges")
                         .header("Authorization", "Bearer " + accessToken)
@@ -83,11 +88,12 @@ class BadgeApiTest {
     void findBadgeThree() throws Exception {
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
-        badgeService.registerBadge(userEmail, BadgeType.ADVENTURE_5.name());
-        badgeService.registerBadge(userEmail, BadgeType.ENGINEER.name());
-        badgeService.registerBadge(userEmail, BadgeType.ATTENDANCE_3.name());
+        badgeService.registerBadge(user, BadgeType.ADVENTURE_5.name());
+        badgeService.registerBadge(user, BadgeType.ENGINEER.name());
+        badgeService.registerBadge(user, BadgeType.ATTENDANCE_3.name());
 
         mockMvc.perform(get("/api/badges")
                         .header("Authorization", "Bearer " + accessToken)
@@ -107,7 +113,8 @@ class BadgeApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User savedUser = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(savedUser).getAccessToken();
 
         BadgeSaveDto badgeSaveDto = new BadgeSaveDto("ATTENDANCE_3");
         String content = objectMapper.writeValueAsString(badgeSaveDto);

--- a/src/test/java/com/playkuround/playkuroundserver/domain/landmark/api/LandmarkApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/landmark/api/LandmarkApiTest.java
@@ -2,10 +2,11 @@ package com.playkuround.playkuroundserver.domain.landmark.api;
 
 import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
 import com.playkuround.playkuroundserver.domain.user.application.UserRegisterService;
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,9 @@ class LandmarkApiTest {
     private UserRepository userRepository;
 
     @Autowired
+    private UserFindDao userFindDao;
+
+    @Autowired
     private UserLoginService userLoginService;
 
     @Autowired
@@ -48,7 +52,8 @@ class LandmarkApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
         // expected
         mockMvc.perform(get("/api/landmarks")
@@ -71,7 +76,8 @@ class LandmarkApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
         // expected
         mockMvc.perform(get("/api/landmarks")
@@ -94,7 +100,8 @@ class LandmarkApiTest {
         // given
         String userEmail = "test@email.com";
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        String accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        String accessToken = userLoginService.login(user).getAccessToken();
 
         // expected
         mockMvc.perform(get("/api/landmarks")

--- a/src/test/java/com/playkuround/playkuroundserver/domain/score/api/ScoreApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/score/api/ScoreApiTest.java
@@ -1,7 +1,6 @@
 package com.playkuround.playkuroundserver.domain.score.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.playkuround.playkuroundserver.domain.score.application.ScoreService;
 import com.playkuround.playkuroundserver.domain.score.dao.ScoreFindDao;
 import com.playkuround.playkuroundserver.domain.score.dao.ScoreRepository;
 import com.playkuround.playkuroundserver.domain.score.domain.Score;
@@ -9,7 +8,9 @@ import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
 import com.playkuround.playkuroundserver.domain.score.dto.ScoreRegisterDto;
 import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
 import com.playkuround.playkuroundserver.domain.user.application.UserRegisterService;
+import com.playkuround.playkuroundserver.domain.user.dao.UserFindDao;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.domain.user.dto.UserRegisterDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,9 @@ class ScoreApiTest {
     private UserRepository userRepository;
 
     @Autowired
+    private UserFindDao userFindDao;
+
+    @Autowired
     private ScoreFindDao scoreFindDao;
 
     @Autowired
@@ -66,7 +70,8 @@ class ScoreApiTest {
     @BeforeEach
     void registerUser() {
         userRegisterService.registerUser(new UserRegisterDto.Request(userEmail, "nickname", "컴퓨터공학부"));
-        accessToken = userLoginService.login(userEmail).getAccessToken();
+        User user = userFindDao.findByEmail(userEmail);
+        accessToken = userLoginService.login(user).getAccessToken();
     }
 
     @Test


### PR DESCRIPTION
## 요약
- 빈 리스트도 응답하도록 변경
- `@UserEmail` -> `@UserEntity`로 변경
- 리프레시 토큰 업데이트 로직 변경
- 회원 등록 시 점수 초기화

<br>

## 작업 내용
- 빈 리스트도 응답하도록 Non_Empty -> Non_Null로 변경

```java
@JsonInclude(value = JsonInclude.Include.NON_NULL)
public class ApiResponse<T> {
```

- 모든 service 클래스에서 userEmail로 user를 갖고 오는 것을 argument resolver를 이용하여 컨트롤러에서 받도록 변경

```java
 @PostMapping
 @ResponseStatus(HttpStatus.CREATED)
  public ApiResponse<Void> saveAdventure(@UserEntity User user, ...) {
    scoreService.saveScore(user, saveScore);
    ...
  }
``` 

- 레디스로 리프레시 토큰을 관리하도록 변경함으로써 update 메서드 추가

```java
@Transactional
public void updateRefreshToken(User user) {
    ...
    refreshToken.updateTimeToLive(Integer.parseInt(refreshTokenTimeToLive));
}
```

- 0점이어도 랭킹에 표시되도록 회원 등록 시 초기화 타입의 점수 생성

```java
public UserRegisterDto.Response registerUser(UserRegisterDto.Request registerRequest) {
    ...
    scoreService.initScore(user);
    ...
}
```

<br>

## 기타
- 기존 서비스 클래스의 파라미터를 userEmail 에서 user로 변경함에 따라 테스트 코드도 그에 맞게 수정함
