### PR TITLE
refactor: user notification

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeService.java
@@ -116,7 +116,7 @@ public class BadgeService {
         Badge badge = Badge.createBadge(user, badgeType);
         badgeRepository.save(badge);
         if (registerMessage) {
-            user.addNewBadgeNotification(badgeType.name());
+            user.addNewBadgeNotification(badgeType);
         }
         return true;
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/api/UserProfileApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/api/UserProfileApi.java
@@ -54,10 +54,10 @@ public class UserProfileApi {
     @GetMapping("/notification")
     @Operation(summary = "유저 알림 얻기",
             description = "유저 개인 알림을 얻습니다. 저장된 메시지는 (정상적인) 호출 이후 삭제됩니다.<br>" +
-                    "=== name 명 리스트 ===<br>" +
+                    "=== name 명 리스트(new_badge는 description도 중요) ===<br>" +
                     "1. 시스템 점검 중일 때(단독으로만 반환): system_check<br>" +
                     "2. 앱 버전 업데이트가 필요할 때(단독으로만 반환): update<br>" +
-                    "3. 새로운 뱃지 획득: new_badge<br>" +
+                    "3. 새로운 뱃지 획득: new_badge(MONTHLY_RANKING_1, MONTHLY_RANKING_2, MONTHLY_RANKING_3, COLLEGE_OF_BUSINESS_ADMINISTRATION_100_AND_FIRST_PLACE)<br>" +
                     "4. 개인 알림: alarm",
             parameters = {
                     @Parameter(name = "version", description = "현재 앱 버전", example = "2.0.2", required = true),

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/api/UserProfileApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/api/UserProfileApi.java
@@ -7,7 +7,8 @@ import com.playkuround.playkuroundserver.domain.user.api.response.UserNotificati
 import com.playkuround.playkuroundserver.domain.user.api.response.UserProfileResponse;
 import com.playkuround.playkuroundserver.domain.user.application.UserProfileService;
 import com.playkuround.playkuroundserver.domain.user.domain.HighestScore;
-import com.playkuround.playkuroundserver.domain.user.dto.UserNotification;
+import com.playkuround.playkuroundserver.domain.user.domain.Notification;
+import com.playkuround.playkuroundserver.domain.user.domain.NotificationEnum;
 import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
 import com.playkuround.playkuroundserver.global.security.UserDetailsImpl;
 import com.playkuround.playkuroundserver.global.util.ApiUtils;
@@ -69,13 +70,13 @@ public class UserProfileApi {
                                                                        @RequestParam(name = "os", required = false, defaultValue = "android") String os) {
         List<UserNotificationResponse> response;
         if (!SystemCheck.isSystemAvailable()) {
-            response = UserNotificationResponse.from(UserNotificationResponse.NotificationEnum.SYSTEM_CHECK);
+            response = UserNotificationResponse.from(NotificationEnum.SYSTEM_CHECK);
         }
         else if (!AppVersion.isLatestUpdatedVersion(os, appVersion)) {
-            response = UserNotificationResponse.from(UserNotificationResponse.NotificationEnum.UPDATE);
+            response = UserNotificationResponse.from(NotificationEnum.UPDATE);
         }
         else {
-            List<UserNotification> notificationList = userProfileService.getNotification(userDetails.getUser());
+            List<Notification> notificationList = userProfileService.getNotification(userDetails.getUser());
             response = UserNotificationResponse.from(notificationList);
         }
         return ApiUtils.success(response);

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/api/response/UserNotificationResponse.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/api/response/UserNotificationResponse.java
@@ -1,6 +1,7 @@
 package com.playkuround.playkuroundserver.domain.user.api.response;
 
-import com.playkuround.playkuroundserver.domain.user.dto.UserNotification;
+import com.playkuround.playkuroundserver.domain.user.domain.Notification;
+import com.playkuround.playkuroundserver.domain.user.domain.NotificationEnum;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,25 +19,12 @@ public class UserNotificationResponse {
     private String description;
 
     public static List<UserNotificationResponse> from(NotificationEnum notificationEnum) {
-        return List.of(new UserNotificationResponse(notificationEnum.name, notificationEnum.description));
+        return List.of(new UserNotificationResponse(notificationEnum.getName(), notificationEnum.getDefaultMessage()));
     }
 
-    public static List<UserNotificationResponse> from(List<UserNotification> notificationList) {
+    public static List<UserNotificationResponse> from(List<Notification> notificationList) {
         return notificationList.stream()
-                .map(notification -> new UserNotificationResponse(notification.name(), notification.description()))
+                .map(notification -> new UserNotificationResponse(notification.getName(), notification.getDescription()))
                 .toList();
-    }
-
-    public enum NotificationEnum {
-        UPDATE("update", "application is must update"),
-        SYSTEM_CHECK("system_check", "system is not available");
-
-        private final String name;
-        private final String description;
-
-        NotificationEnum(String name, String description) {
-            this.name = name;
-            this.description = description;
-        }
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserProfileService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/UserProfileService.java
@@ -2,16 +2,16 @@ package com.playkuround.playkuroundserver.domain.user.application;
 
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.HighestScore;
+import com.playkuround.playkuroundserver.domain.user.domain.Notification;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
-import com.playkuround.playkuroundserver.domain.user.dto.UserNotification;
 import com.playkuround.playkuroundserver.global.util.BadWordFilterUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 @Service
@@ -34,21 +34,16 @@ public class UserProfileService {
     }
 
     @Transactional
-    public List<UserNotification> getNotification(User user) {
-        String str_notification = user.getNotification();
-        if (str_notification == null) {
+    public List<Notification> getNotification(User user) {
+        Set<Notification> notificationSet = user.getNotification();
+        if (notificationSet == null || notificationSet.isEmpty()) {
             return new ArrayList<>();
         }
+
+        List<Notification> userNotifications = notificationSet.stream().toList();
         user.clearNotification();
         userRepository.save(user);
-        return convertToUserNotificationList(str_notification);
-    }
 
-    private List<UserNotification> convertToUserNotificationList(String str_notification) {
-        return Arrays.stream(str_notification.split("@"))
-                .map(notifications -> notifications.split("#"))
-                .filter(nameAndDescription -> nameAndDescription.length == 2)
-                .map(nameAndDescription -> new UserNotification(nameAndDescription[0], nameAndDescription[1]))
-                .toList();
+        return userNotifications;
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/Notification.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/Notification.java
@@ -1,0 +1,21 @@
+package com.playkuround.playkuroundserver.domain.user.domain;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+@EqualsAndHashCode
+public class Notification {
+
+    private final String name;
+    private final String description;
+
+    public Notification(NotificationEnum notificationEnum, String description) {
+        Objects.requireNonNull(notificationEnum, "notificationEnum must be provided");
+
+        this.name = notificationEnum.getName();
+        this.description = (description == null ? "" : description);
+    }
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/NotificationConverter.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/NotificationConverter.java
@@ -1,0 +1,47 @@
+package com.playkuround.playkuroundserver.domain.user.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Converter
+public class NotificationConverter implements AttributeConverter<Set<Notification>, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Set<Notification> notifications) {
+        if (notifications == null) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (Notification notification : notifications) {
+            if (!sb.isEmpty()) {
+                sb.append("@");
+            }
+            sb.append(notification.getName())
+                    .append("#")
+                    .append(notification.getDescription());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public Set<Notification> convertToEntityAttribute(String notifications) {
+        if (notifications == null || notifications.isEmpty()) {
+            return new HashSet<>();
+        }
+        return Arrays.stream(notifications.split("@"))
+                .map(notification -> notification.split("#"))
+                .filter(nameAndDescription -> nameAndDescription.length == 2)
+                .map(nameAndDescription -> {
+                    Optional<NotificationEnum> notificationEnum = NotificationEnum.fromString(nameAndDescription[0]);
+                    return notificationEnum
+                            .map(anEnum -> new Notification(anEnum, nameAndDescription[1]))
+                            .orElse(null);
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/NotificationEnum.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/NotificationEnum.java
@@ -1,0 +1,34 @@
+package com.playkuround.playkuroundserver.domain.user.domain;
+
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+
+@Getter
+public enum NotificationEnum {
+
+    UPDATE("update", "application is must update"),
+    SYSTEM_CHECK("system_check", "system is not available"),
+    ALARM("alarm", "user message"),
+    NEW_BADGE("new_badge", "user get new badge");
+
+    private static final Map<String, NotificationEnum> stringToEnum =
+            Stream.of(values())
+                    .collect(toMap(NotificationEnum::getName, e -> e));
+    private final String name;
+    private final String defaultMessage;
+
+    NotificationEnum(String name, String defaultMessage) {
+        this.name = name;
+        this.defaultMessage = defaultMessage;
+    }
+
+    public static Optional<NotificationEnum> fromString(String source) {
+        return Optional.ofNullable(stringToEnum.get(source));
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/User.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/User.java
@@ -1,10 +1,14 @@
 package com.playkuround.playkuroundserver.domain.user.domain;
 
+import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -36,7 +40,8 @@ public class User extends BaseTimeEntity {
     @Embedded
     private HighestScore highestScore;
 
-    private String notification;
+    @Convert(converter = NotificationConverter.class)
+    private Set<Notification> notification;
 
     private User(String email, String nickname, Major major, Role role) {
         this.email = email;
@@ -61,19 +66,15 @@ public class User extends BaseTimeEntity {
     }
 
     public void clearNotification() {
-        this.notification = null;
-    }
-
-    private void addNotification(String name, String description) {
-        if (notification == null) {
-            notification = name + "#" + description;
-        }
-        else {
-            notification += "@" + name + "#" + description;
+        if (this.notification != null) {
+            this.notification.clear();
         }
     }
 
-    public void addNewBadgeNotification(String description) {
-        addNotification("new_badge", description);
+    public void addNewBadgeNotification(BadgeType badgeType) {
+        if (this.notification == null) {
+            this.notification = new HashSet<>();
+        }
+        this.notification.add(new Notification(NotificationEnum.NEW_BADGE, badgeType.name()));
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -64,6 +64,9 @@
         <root level="info">
             <appender-ref ref="STDOUT"/>
         </root>
+        <logger name="org.hibernate.SQL" level="debug" additivity="false">
+            <appender-ref ref="STDOUT"/>
+        </logger>
     </springProfile>
 
     <!--  local 환경  -->

--- a/src/test/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeServiceTest.java
@@ -9,6 +9,8 @@ import com.playkuround.playkuroundserver.domain.badge.dto.NewlyRegisteredBadge;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.landmark.domain.LandmarkType;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
+import com.playkuround.playkuroundserver.domain.user.domain.Notification;
+import com.playkuround.playkuroundserver.domain.user.domain.NotificationEnum;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.util.DateUtils;
 import org.junit.jupiter.api.DisplayName;
@@ -385,7 +387,8 @@ class BadgeServiceTest {
 
             // then
             assertThat(result).isTrue();
-            assertThat(user.getNotification()).isEqualTo("new_badge#" + badgeType.name());
+            assertThat(user.getNotification())
+                    .containsOnly(new Notification(NotificationEnum.NEW_BADGE, badgeType.name()));
         }
     }
 

--- a/src/test/java/com/playkuround/playkuroundserver/domain/user/api/AdminApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/user/api/AdminApiTest.java
@@ -9,9 +9,7 @@ import com.playkuround.playkuroundserver.domain.common.AppVersion;
 import com.playkuround.playkuroundserver.domain.common.SystemCheck;
 import com.playkuround.playkuroundserver.domain.user.api.request.ManualBadgeSaveRequest;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
-import com.playkuround.playkuroundserver.domain.user.domain.Major;
-import com.playkuround.playkuroundserver.domain.user.domain.Role;
-import com.playkuround.playkuroundserver.domain.user.domain.User;
+import com.playkuround.playkuroundserver.domain.user.domain.*;
 import com.playkuround.playkuroundserver.securityConfig.WithMockCustomUser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -190,7 +189,9 @@ class AdminApiTest {
             assertThat(badges.get(0).getBadgeType()).isEqualTo(BadgeType.MONTHLY_RANKING_1);
 
             Optional<User> optionalUser = userRepository.findByEmail(user.getEmail());
-            assertThat(optionalUser.get().getNotification()).isEqualTo("new_badge#" + BadgeType.MONTHLY_RANKING_1.name());
+            Set<Notification> notification = optionalUser.get().getNotification();
+            assertThat(notification)
+                    .containsOnly(new Notification(NotificationEnum.NEW_BADGE, BadgeType.MONTHLY_RANKING_1.name()));
         }
 
         @Test

--- a/src/test/java/com/playkuround/playkuroundserver/domain/user/application/UserProfileServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/user/application/UserProfileServiceTest.java
@@ -1,9 +1,11 @@
 package com.playkuround.playkuroundserver.domain.user.application;
 
 import com.playkuround.playkuroundserver.TestUtil;
+import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
+import com.playkuround.playkuroundserver.domain.user.domain.Notification;
+import com.playkuround.playkuroundserver.domain.user.domain.NotificationEnum;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
-import com.playkuround.playkuroundserver.domain.user.dto.UserNotification;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -95,7 +97,7 @@ class UserProfileServiceTest {
             User user = TestUtil.createUser();
 
             // when
-            List<UserNotification> result = userProfileService.getNotification(user);
+            List<Notification> result = userProfileService.getNotification(user);
 
             // then
             assertThat(result).isEmpty();
@@ -106,16 +108,16 @@ class UserProfileServiceTest {
         void success_2() {
             // given
             User user = TestUtil.createUser();
-            user.addNewBadgeNotification("new badge");
+            user.addNewBadgeNotification(BadgeType.MONTHLY_RANKING_1);
 
             // when
-            List<UserNotification> result = userProfileService.getNotification(user);
+            List<Notification> result = userProfileService.getNotification(user);
 
             // then
             assertThat(result).hasSize(1);
-            assertThat(result.get(0).name()).isEqualTo("new_badge");
-            assertThat(result.get(0).description()).isEqualTo("new badge");
-            assertThat(user.getNotification()).isNull();
+            assertThat(result.get(0).getName()).isEqualTo("new_badge");
+            assertThat(result.get(0).getDescription()).isEqualTo(BadgeType.MONTHLY_RANKING_1.name());
+            assertThat(user.getNotification()).isEmpty();
         }
 
         @Test
@@ -123,19 +125,18 @@ class UserProfileServiceTest {
         void success_3() {
             // given
             User user = TestUtil.createUser();
-            user.addNewBadgeNotification("new badge1");
-            user.addNewBadgeNotification("new badge2");
+            user.addNewBadgeNotification(BadgeType.MONTHLY_RANKING_1);
+            user.addNewBadgeNotification(BadgeType.MONTHLY_RANKING_2);
 
             // when
-            List<UserNotification> result = userProfileService.getNotification(user);
+            List<Notification> result = userProfileService.getNotification(user);
 
             // then
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0).name()).isEqualTo("new_badge");
-            assertThat(result.get(0).description()).isEqualTo("new badge1");
-            assertThat(result.get(1).name()).isEqualTo("new_badge");
-            assertThat(result.get(1).description()).isEqualTo("new badge2");
-            assertThat(user.getNotification()).isNull();
+            assertThat(result).containsOnly(
+                    new Notification(NotificationEnum.NEW_BADGE, BadgeType.MONTHLY_RANKING_1.name()),
+                    new Notification(NotificationEnum.NEW_BADGE, BadgeType.MONTHLY_RANKING_2.name())
+            );
+            assertThat(user.getNotification()).isEmpty();
         }
 
     }


### PR DESCRIPTION
## 요약
User 테이블의 text 타입의 notification을 직접 파싱하여 도메인 메서드로 지원하던 기능을,
`@Convert`를 이용하여 Set collection을 entity에서 사용하도록 변경
