### PR TITLE
새로운 월(month) 업데이트 API

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -13,11 +13,14 @@ import com.playkuround.playkuroundserver.domain.score.application.TotalScoreServ
 import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
+import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 import com.playkuround.playkuroundserver.global.util.Location;
 import com.playkuround.playkuroundserver.global.util.LocationDistanceUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -63,7 +66,8 @@ public class AdventureService {
     }
 
     private void updateLandmarkHighestScore(User user, Landmark landmark) {
-        long sumScore = adventureRepository.getSumScoreByUserAndLandmark(user, landmark);
+        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime();
+        long sumScore = adventureRepository.getSumScoreByUserAndLandmark(user, landmark, monthStartDateTime);
         landmark.updateFirstUser(user, sumScore);
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,11 +18,11 @@ public interface AdventureRepository extends JpaRepository<Adventure, Long> {
     @Query(value =
             "SELECT new com.playkuround.playkuroundserver.domain.score.dto.NicknameAndScore(a.user.nickname, cast(SUM(a.score) as integer)) " +
                     "FROM Adventure a " +
-                    "where a.landmark.id=:landmark " +
+                    "where a.landmark.id=:landmark AND a.createdAt >= :from " +
                     "GROUP BY a.user.id " +
                     "ORDER BY SUM(a.score) DESC, a.user.nickname DESC " +
                     "LIMIT 100")
-    List<NicknameAndScore> findRankTop100DescByLandmarkId(@Param(value = "landmark") Long landmarkId);
+    List<NicknameAndScore> findRankTop100DescByLandmarkId(@Param(value = "landmark") Long landmarkId, @Param(value = "from") LocalDateTime from);
 
     @Query(value =
             "SELECT new com.playkuround.playkuroundserver.domain.score.dto.RankAndScore(cast(user_rank as integer), cast(score as integer)) FROM " +

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
@@ -28,10 +28,12 @@ public interface AdventureRepository extends JpaRepository<Adventure, Long> {
             "SELECT new com.playkuround.playkuroundserver.domain.score.dto.RankAndScore(cast(user_rank as integer), cast(score as integer)) FROM " +
                     "(SELECT a.user.id as user_id, (RANK() over (order by SUM(a.score) desc)) as user_rank, SUM(a.score) as score " +
                     "FROM Adventure a " +
-                    "where a.landmark.id=:landmark " +
+                    "where a.landmark.id=:landmark AND a.createdAt >= :from " +
                     "GROUP BY a.user.id) " +
                     "where user_id=:#{#user.id}")
-    Optional<RankAndScore> findMyRankByLandmarkId(@Param(value = "user") User user, @Param(value = "landmark") Long landmarkId);
+    Optional<RankAndScore> findMyRankByLandmarkId(@Param(value = "user") User user,
+                                                  @Param(value = "landmark") Long landmarkId,
+                                                  @Param(value = "from") LocalDateTime from);
 
     @Query("SELECT SUM(a.score) FROM Adventure a WHERE a.user.id=:#{#user.id} AND a.landmark.id=:#{#landmark.id}")
     long getSumScoreByUserAndLandmark(@Param(value = "user") User user, @Param(value = "landmark") Landmark landmark);

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/dao/AdventureRepository.java
@@ -35,8 +35,12 @@ public interface AdventureRepository extends JpaRepository<Adventure, Long> {
                                                   @Param(value = "landmark") Long landmarkId,
                                                   @Param(value = "from") LocalDateTime from);
 
-    @Query("SELECT SUM(a.score) FROM Adventure a WHERE a.user.id=:#{#user.id} AND a.landmark.id=:#{#landmark.id}")
-    long getSumScoreByUserAndLandmark(@Param(value = "user") User user, @Param(value = "landmark") Landmark landmark);
+    @Query("SELECT SUM(a.score) " +
+            "FROM Adventure a " +
+            "WHERE a.user.id=:#{#user.id} AND a.landmark.id=:#{#landmark.id} AND a.createdAt >= :from")
+    long getSumScoreByUserAndLandmark(@Param(value = "user") User user,
+                                      @Param(value = "landmark") Landmark landmark,
+                                      @Param(value = "from") LocalDateTime from);
 
     long countByUserAndLandmark(User user, Landmark requestSaveLandmark);
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/ArborDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/ArborDayBadge.java
@@ -1,7 +1,7 @@
 package com.playkuround.playkuroundserver.domain.badge.application.specialday_badge;
 
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
-import com.playkuround.playkuroundserver.global.util.DateUtils;
+import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
 import java.util.Set;
 
@@ -13,7 +13,7 @@ public class ArborDayBadge implements SpecialDayBadge {
     @Override
     public boolean supports(Set<BadgeType> userBadgeSet) {
         BadgeType badgeType = getBadgeType();
-        return DateUtils.isTodayArborDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isTodayArborDay() && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/ChildrenDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/ChildrenDayBadge.java
@@ -1,7 +1,7 @@
 package com.playkuround.playkuroundserver.domain.badge.application.specialday_badge;
 
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
-import com.playkuround.playkuroundserver.global.util.DateUtils;
+import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
 import java.util.Set;
 
@@ -13,7 +13,7 @@ public class ChildrenDayBadge implements SpecialDayBadge {
     @Override
     public boolean supports(Set<BadgeType> userBadgeSet) {
         BadgeType badgeType = getBadgeType();
-        return DateUtils.isTodayChildrenDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isTodayChildrenDay() && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/DuckDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/DuckDayBadge.java
@@ -1,7 +1,7 @@
 package com.playkuround.playkuroundserver.domain.badge.application.specialday_badge;
 
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
-import com.playkuround.playkuroundserver.global.util.DateUtils;
+import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
 import java.util.Set;
 
@@ -13,7 +13,7 @@ public class DuckDayBadge implements SpecialDayBadge {
     @Override
     public boolean supports(Set<BadgeType> userBadgeSet) {
         BadgeType badgeType = getBadgeType();
-        return DateUtils.isTodayDuckDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isTodayDuckDay() && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/FoundationDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/FoundationDayBadge.java
@@ -1,7 +1,7 @@
 package com.playkuround.playkuroundserver.domain.badge.application.specialday_badge;
 
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
-import com.playkuround.playkuroundserver.global.util.DateUtils;
+import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
 import java.util.Set;
 
@@ -13,7 +13,7 @@ public class FoundationDayBadge implements SpecialDayBadge {
     @Override
     public boolean supports(Set<BadgeType> userBadgeSet) {
         BadgeType badgeType = getBadgeType();
-        return DateUtils.isTodayFoundationDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isTodayFoundationDay() && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/WhiteDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/WhiteDayBadge.java
@@ -1,7 +1,7 @@
 package com.playkuround.playkuroundserver.domain.badge.application.specialday_badge;
 
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
-import com.playkuround.playkuroundserver.global.util.DateUtils;
+import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
 import java.util.Set;
 
@@ -13,7 +13,7 @@ public class WhiteDayBadge implements SpecialDayBadge {
     @Override
     public boolean supports(Set<BadgeType> userBadgeSet) {
         BadgeType badgeType = getBadgeType();
-        return DateUtils.isTodayWhiteDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isTodayWhiteDay() && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/dao/BadgeRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/dao/BadgeRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
     List<Badge> findByUser(User user);
 
-    boolean existsByUserAndBadgeType(User user, BadgeType conqueror);
+    boolean existsByUserAndBadgeType(User user, BadgeType badgeType);
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/landmark/domain/Landmark.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/landmark/domain/Landmark.java
@@ -41,4 +41,9 @@ public class Landmark {
             this.highestScore = score;
         }
     }
+
+    public void deleteRank() {
+        this.firstUser = null;
+        this.highestScore = 0;
+    }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankService.java
@@ -22,13 +22,13 @@ public class LandmarkRankService {
     @Transactional(readOnly = true)
     public ScoreRankingResponse getRankTop100ByLandmark(User user, Long landmarkId) {
         ScoreRankingResponse response = ScoreRankingResponse.createEmptyResponse();
-
         LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime();
+
         List<NicknameAndScore> nicknameAndScores = adventureRepository.findRankTop100DescByLandmarkId(landmarkId, monthStartDateTime);
         nicknameAndScores.forEach(nicknameAndScore ->
                 response.addRank(nicknameAndScore.nickname(), nicknameAndScore.score()));
 
-        RankAndScore rankAndScore = adventureRepository.findMyRankByLandmarkId(user, landmarkId)
+        RankAndScore rankAndScore = adventureRepository.findMyRankByLandmarkId(user, landmarkId, monthStartDateTime)
                 .orElseGet(() -> new RankAndScore(0, 0));
         response.setMyRank(rankAndScore.ranking(), rankAndScore.score());
         return response;

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankService.java
@@ -5,10 +5,12 @@ import com.playkuround.playkuroundserver.domain.score.dto.NicknameAndScore;
 import com.playkuround.playkuroundserver.domain.score.dto.RankAndScore;
 import com.playkuround.playkuroundserver.domain.score.dto.response.ScoreRankingResponse;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
+import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -21,7 +23,8 @@ public class LandmarkRankService {
     public ScoreRankingResponse getRankTop100ByLandmark(User user, Long landmarkId) {
         ScoreRankingResponse response = ScoreRankingResponse.createEmptyResponse();
 
-        List<NicknameAndScore> nicknameAndScores = adventureRepository.findRankTop100DescByLandmarkId(landmarkId);
+        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime();
+        List<NicknameAndScore> nicknameAndScores = adventureRepository.findRankTop100DescByLandmarkId(landmarkId, monthStartDateTime);
         nicknameAndScores.forEach(nicknameAndScore ->
                 response.addRank(nicknameAndScore.nickname(), nicknameAndScore.score()));
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/api/AdminApi.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/api/AdminApi.java
@@ -5,6 +5,7 @@ import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.common.AppVersion;
 import com.playkuround.playkuroundserver.domain.common.SystemCheck;
 import com.playkuround.playkuroundserver.domain.user.api.request.ManualBadgeSaveRequest;
+import com.playkuround.playkuroundserver.domain.user.application.NewMonthUpdateService;
 import com.playkuround.playkuroundserver.global.common.response.ApiResponse;
 import com.playkuround.playkuroundserver.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,9 +23,10 @@ import org.springframework.web.bind.annotation.*;
 public class AdminApi {
 
     private final BadgeService badgeService;
+    private final NewMonthUpdateService newMonthUpdateService;
 
     @PostMapping("/app-version")
-    @Operation(summary = "앱 버전 올리기(관리자모드)", description = "앱 버전을 올립니다. 이전버전 사용자에게 공지 메시지를 보냅니다.",
+    @Operation(summary = "앱 버전 올리기", description = "앱 버전을 올립니다. 이전버전 사용자에게 공지 메시지를 보냅니다.",
             parameters = {
                     @Parameter(name = "version", description = "최신 앱 버전", example = "2.0.2", required = true),
                     @Parameter(name = "os", description = "모바일 운영체제(android 또는 ios)", example = "android", required = true)
@@ -37,7 +39,7 @@ public class AdminApi {
     }
 
     @PostMapping("/system-available")
-    @Operation(summary = "시스템 점검 유무 변경하기(관리자모드)", description = "시스템 점검 유무를 변경합니다.")
+    @Operation(summary = "시스템 점검 유무 변경하기", description = "시스템 점검 유무를 변경합니다.")
     public ApiResponse<Void> changeSystemAvailable(@RequestParam("available") boolean appVersion) {
         SystemCheck.changeSystemAvailable(appVersion);
         return ApiUtils.success(null);
@@ -45,12 +47,24 @@ public class AdminApi {
 
     @PostMapping("badges/manual")
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "수동 뱃지 등록(관리자권한)", description = "수동으로 뱃지를 등록합니다. 이미 획득한 뱃지였다면 false를 반환합니다. " +
+    @Operation(summary = "수동 뱃지 등록", description = "수동으로 뱃지를 등록합니다. 이미 획득한 뱃지였다면 false를 반환합니다. " +
             "설정에 따라 개인 메시지로 등록할 수 있습니다.")
     public ApiResponse<Boolean> saveManualBadge(@RequestBody @Valid ManualBadgeSaveRequest request) {
         BadgeType badgeType = BadgeType.valueOf(request.getBadge());
         boolean response = badgeService.saveManualBadge(request.getUserEmail(), badgeType, request.isRegisterMessage());
         return ApiUtils.success(response);
+    }
+
+    @PostMapping("new-month-update")
+    @Operation(summary = "월(month) 업데이트",
+            description = "== 해당 API는 아래의 작업을 포함합니다. ==<br>" +
+                    "1. MONTHLY_RANKING_1, MONTHLY_RANKING_2, MONTHLY_RANKING_3 부여(+메시지 부여)<br>" +
+                    "2. 랜드마크별 랭킹 초기화<br>" +
+                    "3. 유저별 최고 랭킹, 스코어 기록<br>" +
+                    "4. 종합 랭킹 초기화")
+    public ApiResponse<Void> updateNewMonth() {
+        newMonthUpdateService.updateMonth();
+        return ApiUtils.success(null);
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/application/NewMonthUpdateService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/application/NewMonthUpdateService.java
@@ -1,0 +1,120 @@
+package com.playkuround.playkuroundserver.domain.user.application;
+
+import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
+import com.playkuround.playkuroundserver.domain.badge.domain.Badge;
+import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
+import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
+import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
+import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
+import com.playkuround.playkuroundserver.domain.user.domain.User;
+import com.playkuround.playkuroundserver.domain.user.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.lang.Math.min;
+
+@Service
+@RequiredArgsConstructor
+public class NewMonthUpdateService {
+
+    private final String redisSetKey = "ranking";
+    private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
+    private final BadgeRepository badgeRepository;
+    private final LandmarkRepository landmarkRepository;
+
+    @Transactional
+    public void updateMonth() {
+        List<RankData> totalRankDateList = getTotalRankDateList();
+        saveBadge(totalRankDateList);
+        updateUserHighestRank(totalRankDateList);
+        updateLandmarkRank();
+        deleteAllTotalScoreRepository();
+    }
+
+    private List<RankData> getTotalRankDateList() {
+        Set<ZSetOperations.TypedTuple<String>> totalScoreTypedTuples = getTotalScoreTypedTuples();
+
+        List<RankData> rankDataList = new ArrayList<>();
+        long rank = 1;
+        for (ZSetOperations.TypedTuple<String> typedTuple : totalScoreTypedTuples) {
+            if (typedTuple.getValue() == null || typedTuple.getScore() == null) {
+                throw new RuntimeException("typedTuple value or score is null");
+            }
+            rankDataList.add(new RankData(typedTuple.getValue(), rank, typedTuple.getScore().longValue()));
+            rank++;
+        }
+        return rankDataList;
+    }
+
+    private Set<ZSetOperations.TypedTuple<String>> getTotalScoreTypedTuples() {
+        ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();
+        Long zSetSize = zSetOperations.size(redisSetKey);
+        if (zSetSize == null) {
+            throw new RuntimeException("zSetSize is null");
+        }
+
+        Set<ZSetOperations.TypedTuple<String>> typedTuples
+                = zSetOperations.reverseRangeWithScores(redisSetKey, 0, zSetSize - 1);
+        if (typedTuples == null) {
+            throw new RuntimeException("typedTuples is null");
+        }
+        return typedTuples;
+    }
+
+    private void saveBadge(List<RankData> rankDataList) {
+        BadgeType[] monthlyRankingBadges = {BadgeType.MONTHLY_RANKING_1, BadgeType.MONTHLY_RANKING_2, BadgeType.MONTHLY_RANKING_3};
+        int maxIter = min(monthlyRankingBadges.length, rankDataList.size());
+
+        for (int i = 0; i < maxIter; i++) {
+            BadgeType badgeType = monthlyRankingBadges[i];
+            RankData rankData = rankDataList.get(i);
+
+            User user = userRepository.findByEmail(rankData.email)
+                    .orElseThrow(UserNotFoundException::new);
+            if (!badgeRepository.existsByUserAndBadgeType(user, badgeType)) {
+                Badge badge = Badge.createBadge(user, badgeType);
+                badgeRepository.save(badge);
+                user.addNewBadgeNotification(badgeType);
+            }
+        }
+    }
+
+    private void updateUserHighestRank(List<RankData> rankDataList) {
+        List<String> emailList = rankDataList.stream()
+                .map(RankData::email)
+                .toList();
+        List<User> users = userRepository.findByEmailIn(emailList);
+        Map<String, User> mapEmailToUser = users.stream()
+                .collect(Collectors.toMap(User::getEmail, user -> user));
+
+        for (RankData rankData : rankDataList) {
+            User user = mapEmailToUser.get(rankData.email);
+            if (user == null) {
+                throw new UserNotFoundException();
+            }
+            user.updateHighestRank(rankData.rank, rankData.score);
+        }
+    }
+
+    private void updateLandmarkRank() {
+        landmarkRepository.findAll()
+                .forEach(Landmark::deleteRank);
+    }
+
+    private void deleteAllTotalScoreRepository() {
+        redisTemplate.delete(redisSetKey);
+    }
+
+    private record RankData(String email, long rank, long score) {
+    }
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/dao/UserRepository.java
@@ -20,4 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "from User u " +
             "where u.email in :emails")
     List<EmailAndNickname> findNicknameByEmailIn(List<String> emails);
+
+    List<User> findByEmailIn(List<String> emailList);
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/HighestScore.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/HighestScore.java
@@ -23,6 +23,16 @@ public class HighestScore {
     private Long highestAllClearScore;
     private Long highestMicrobeScore;
 
+    public void updateHighestTotalLank(long rank, long score) {
+        if (this.highestTotalRank == null || this.highestTotalScore < score) {
+            this.highestTotalScore = score;
+            this.highestTotalRank = rank;
+        }
+        else if (this.highestTotalScore == score && this.highestTotalRank > rank) {
+            this.highestTotalRank = rank;
+        }
+    }
+
     public void updateGameHighestScore(ScoreType scoreType, Long score) {
         switch (scoreType) {
             case QUIZ -> updateHighestQuizScore(score);

--- a/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/User.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/user/domain/User.java
@@ -77,4 +77,9 @@ public class User extends BaseTimeEntity {
         }
         this.notification.add(new Notification(NotificationEnum.NEW_BADGE, badgeType.name()));
     }
+
+    public void updateHighestRank(long rank, long score) {
+        HighestScore highestScore = getHighestScore();
+        highestScore.updateHighestTotalLank(rank, score);
+    }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/global/util/DateTimeUtils.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/util/DateTimeUtils.java
@@ -3,9 +3,15 @@ package com.playkuround.playkuroundserver.global.util;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
-public class DateUtils {
+public class DateTimeUtils {
+
+    public static LocalDateTime getMonthStartDateTime() {
+        LocalDate today = LocalDate.now();
+        return today.withDayOfMonth(1).atStartOfDay();
+    }
 
     public static boolean isTodayFoundationDay() {
         LocalDate today = LocalDate.now();

--- a/src/test/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeServiceTest.java
@@ -12,7 +12,7 @@ import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.Notification;
 import com.playkuround.playkuroundserver.domain.user.domain.NotificationEnum;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
-import com.playkuround.playkuroundserver.global.util.DateUtils;
+import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -133,12 +133,12 @@ class BadgeServiceTest {
             when(badgeRepository.findByUser(user)).thenReturn(new ArrayList<>());
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
-            try (MockedStatic<DateUtils> mockedStatic = Mockito.mockStatic(DateUtils.class)) {
-                mockedStatic.when(DateUtils::isTodayDuckDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayArborDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayWhiteDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayChildrenDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayFoundationDay).thenReturn(false);
+            try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
+                mockedStatic.when(DateTimeUtils::isTodayDuckDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayArborDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayWhiteDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayChildrenDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayFoundationDay).thenReturn(false);
 
                 // when
                 NewlyRegisteredBadge newlyRegisteredBadge = badgeService.updateNewlyAttendanceBadges(user);
@@ -160,12 +160,12 @@ class BadgeServiceTest {
             when(badgeRepository.findByUser(user)).thenReturn(new ArrayList<>());
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
-            try (MockedStatic<DateUtils> mockedStatic = Mockito.mockStatic(DateUtils.class)) {
-                mockedStatic.when(DateUtils::isTodayDuckDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayArborDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayWhiteDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayChildrenDay).thenReturn(true);
-                mockedStatic.when(DateUtils::isTodayFoundationDay).thenReturn(false);
+            try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
+                mockedStatic.when(DateTimeUtils::isTodayDuckDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayArborDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayWhiteDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayChildrenDay).thenReturn(true);
+                mockedStatic.when(DateTimeUtils::isTodayFoundationDay).thenReturn(false);
 
                 // when
                 NewlyRegisteredBadge newlyRegisteredBadge = badgeService.updateNewlyAttendanceBadges(user);
@@ -193,12 +193,12 @@ class BadgeServiceTest {
                     ));
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
-            try (MockedStatic<DateUtils> mockedStatic = Mockito.mockStatic(DateUtils.class)) {
-                mockedStatic.when(DateUtils::isTodayDuckDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayWhiteDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayArborDay).thenReturn(false);
-                mockedStatic.when(DateUtils::isTodayChildrenDay).thenReturn(true);
-                mockedStatic.when(DateUtils::isTodayFoundationDay).thenReturn(false);
+            try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
+                mockedStatic.when(DateTimeUtils::isTodayDuckDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayWhiteDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayArborDay).thenReturn(false);
+                mockedStatic.when(DateTimeUtils::isTodayChildrenDay).thenReturn(true);
+                mockedStatic.when(DateTimeUtils::isTodayFoundationDay).thenReturn(false);
 
                 // when
                 NewlyRegisteredBadge newlyRegisteredBadge = badgeService.updateNewlyAttendanceBadges(user);

--- a/src/test/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankServiceTest.java
@@ -14,9 +14,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,13 +35,13 @@ class LandmarkRankServiceTest {
     @DisplayName("랭킹 유저가 한명도 없을 때")
     void getRankTop100ByLandmark1() {
         // given
-        User user = TestUtil.createUser();
         when(adventureRepository.findRankTop100DescByLandmarkId(any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(List.of());
-        when(adventureRepository.findMyRankByLandmarkId(user, 1L))
+        when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.empty());
 
         // when
+        User user = TestUtil.createUser();
         ScoreRankingResponse result = landmarkRankService.getRankTop100ByLandmark(user, 1L);
 
         // then
@@ -54,16 +54,16 @@ class LandmarkRankServiceTest {
     @DisplayName("전체 유저 100명 미만 + 내 랭킹은 없음")
     void getRankTop100ByLandmark2() {
         // given
-        List<NicknameAndScore> nicknameAndScores = new ArrayList<>();
-        for (int i = 50; i > 0; i--) {
-            nicknameAndScores.add(new NicknameAndScore("nickname" + i, i));
-        }
+        List<NicknameAndScore> nicknameAndScores = IntStream.rangeClosed(1, 50)
+                .mapToObj(i -> new NicknameAndScore("nickname" + (51 - i), 51 - i))
+                .toList();
         when(adventureRepository.findRankTop100DescByLandmarkId(any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(nicknameAndScores);
-        User user = TestUtil.createUser();
-        when(adventureRepository.findMyRankByLandmarkId(user, 1L)).thenReturn(Optional.empty());
+        when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
+                .thenReturn(Optional.empty());
 
         // when
+        User user = TestUtil.createUser();
         ScoreRankingResponse result = landmarkRankService.getRankTop100ByLandmark(user, 1L);
 
         // then
@@ -82,17 +82,16 @@ class LandmarkRankServiceTest {
     @DisplayName("전체 유저 100명 미만 + 내 랭킹 존재")
     void getRankTop100ByLandmark3() {
         // given
-        List<NicknameAndScore> nicknameAndScores = new ArrayList<>();
-        for (int i = 50; i > 0; i--) {
-            nicknameAndScores.add(new NicknameAndScore("nickname" + i, i));
-        }
+        List<NicknameAndScore> nicknameAndScores = IntStream.rangeClosed(1, 50)
+                .mapToObj(i -> new NicknameAndScore("nickname" + (51 - i), 51 - i))
+                .toList();
         when(adventureRepository.findRankTop100DescByLandmarkId(any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(nicknameAndScores);
-        User user = TestUtil.createUser();
-        when(adventureRepository.findMyRankByLandmarkId(user, 1L))
+        when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.of(new RankAndScore(14, 37)));
 
         // when
+        User user = TestUtil.createUser();
         ScoreRankingResponse result = landmarkRankService.getRankTop100ByLandmark(user, 1L);
 
         // then
@@ -110,17 +109,16 @@ class LandmarkRankServiceTest {
     @DisplayName("전체 유저 100명 초과 + 내 랭킹 중간에 존재")
     void getRankTop100ByLandmark4() {
         // given
-        List<NicknameAndScore> nicknameAndScores = new ArrayList<>();
-        for (int i = 101; i > 0; i--) {
-            nicknameAndScores.add(new NicknameAndScore("nickname" + i, i));
-        }
+        List<NicknameAndScore> nicknameAndScores = IntStream.rangeClosed(1, 101)
+                .mapToObj(i -> new NicknameAndScore("nickname" + (102 - i), 102 - i))
+                .toList();
         when(adventureRepository.findRankTop100DescByLandmarkId(any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(nicknameAndScores);
-        User user = TestUtil.createUser();
-        when(adventureRepository.findMyRankByLandmarkId(user, 1L))
+        when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.of(new RankAndScore(40, 62)));
 
         // when
+        User user = TestUtil.createUser();
         ScoreRankingResponse result = landmarkRankService.getRankTop100ByLandmark(user, 1L);
 
         // then

--- a/src/test/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankServiceTest.java
@@ -13,11 +13,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,7 +36,7 @@ class LandmarkRankServiceTest {
     void getRankTop100ByLandmark1() {
         // given
         User user = TestUtil.createUser();
-        when(adventureRepository.findRankTop100DescByLandmarkId(1L))
+        when(adventureRepository.findRankTop100DescByLandmarkId(any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(List.of());
         when(adventureRepository.findMyRankByLandmarkId(user, 1L))
                 .thenReturn(Optional.empty());
@@ -56,7 +58,8 @@ class LandmarkRankServiceTest {
         for (int i = 50; i > 0; i--) {
             nicknameAndScores.add(new NicknameAndScore("nickname" + i, i));
         }
-        when(adventureRepository.findRankTop100DescByLandmarkId(1L)).thenReturn(nicknameAndScores);
+        when(adventureRepository.findRankTop100DescByLandmarkId(any(Long.class), any(LocalDateTime.class)))
+                .thenReturn(nicknameAndScores);
         User user = TestUtil.createUser();
         when(adventureRepository.findMyRankByLandmarkId(user, 1L)).thenReturn(Optional.empty());
 
@@ -83,7 +86,8 @@ class LandmarkRankServiceTest {
         for (int i = 50; i > 0; i--) {
             nicknameAndScores.add(new NicknameAndScore("nickname" + i, i));
         }
-        when(adventureRepository.findRankTop100DescByLandmarkId(1L)).thenReturn(nicknameAndScores);
+        when(adventureRepository.findRankTop100DescByLandmarkId(any(Long.class), any(LocalDateTime.class)))
+                .thenReturn(nicknameAndScores);
         User user = TestUtil.createUser();
         when(adventureRepository.findMyRankByLandmarkId(user, 1L))
                 .thenReturn(Optional.of(new RankAndScore(14, 37)));
@@ -110,7 +114,8 @@ class LandmarkRankServiceTest {
         for (int i = 101; i > 0; i--) {
             nicknameAndScores.add(new NicknameAndScore("nickname" + i, i));
         }
-        when(adventureRepository.findRankTop100DescByLandmarkId(1L)).thenReturn(nicknameAndScores);
+        when(adventureRepository.findRankTop100DescByLandmarkId(any(Long.class), any(LocalDateTime.class)))
+                .thenReturn(nicknameAndScores);
         User user = TestUtil.createUser();
         when(adventureRepository.findMyRankByLandmarkId(user, 1L))
                 .thenReturn(Optional.of(new RankAndScore(40, 62)));


### PR DESCRIPTION
## 요약
매월 1일에 다음과 같은 작업을 수행합니다.(수동 호출)
1. MONTHLY_RANKING_1, MONTHLY_RANKING_2, MONTHLY_RANKING_3 부여(+메시지 부여)
2. 랜드마크별 랭킹 초기화
3. 유저별 최고 랭킹, 스코어 기록
4. 종합 랭킹 초기화

