### PR TITLE
날짜, 시간 관련 코드 수정 (DateTimeService, attendanceDateTime field)

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -68,7 +68,7 @@ public class AdventureService {
     }
 
     private void updateLandmarkHighestScore(User user, Landmark landmark) {
-        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime(dateTimeService.now().toLocalDate());
+        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime(dateTimeService.getLocalDateNow());
         long sumScore = adventureRepository.getSumScoreByUserAndLandmark(user, landmark, monthStartDateTime);
         landmark.updateFirstUser(user, sumScore);
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/adventure/application/AdventureService.java
@@ -6,6 +6,7 @@ import com.playkuround.playkuroundserver.domain.adventure.dto.AdventureSaveDto;
 import com.playkuround.playkuroundserver.domain.adventure.exception.InvalidLandmarkLocationException;
 import com.playkuround.playkuroundserver.domain.badge.application.BadgeService;
 import com.playkuround.playkuroundserver.domain.badge.dto.NewlyRegisteredBadge;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.landmark.exception.LandmarkNotFoundException;
@@ -31,6 +32,7 @@ public class AdventureService {
     private final TotalScoreService totalScoreService;
     private final LandmarkRepository landmarkRepository;
     private final AdventureRepository adventureRepository;
+    private final DateTimeService dateTimeService;
 
     @Transactional
     public NewlyRegisteredBadge saveAdventure(AdventureSaveDto adventureSaveDto) {
@@ -66,7 +68,7 @@ public class AdventureService {
     }
 
     private void updateLandmarkHighestScore(User user, Landmark landmark) {
-        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime();
+        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime(dateTimeService.now().toLocalDate());
         long sumScore = adventureRepository.getSumScoreByUserAndLandmark(user, landmark, monthStartDateTime);
         landmark.updateFirstUser(user, sumScore);
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterService.java
@@ -16,8 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-
 @Service
 @RequiredArgsConstructor
 public class AttendanceRegisterService {
@@ -54,13 +52,13 @@ public class AttendanceRegisterService {
     }
 
     private void validateDuplicateAttendance(User user) {
-        if (attendanceRepository.existsByUserAndAttendanceDateTimeAfter(user, LocalDate.now().atStartOfDay())) {
+        if (attendanceRepository.existsByUserAndAttendanceDateTimeAfter(user, dateTimeService.getLocalDateNow().atStartOfDay())) {
             throw new DuplicateAttendanceException();
         }
     }
 
     private void saveAttendance(User user, Location location) {
-        Attendance attendance = Attendance.of(user, location, dateTimeService.now());
+        Attendance attendance = Attendance.of(user, location, dateTimeService.getLocalDateTimeNow());
         attendanceRepository.save(attendance);
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterService.java
@@ -6,6 +6,7 @@ import com.playkuround.playkuroundserver.domain.attendance.exception.DuplicateAt
 import com.playkuround.playkuroundserver.domain.attendance.exception.InvalidAttendanceLocationException;
 import com.playkuround.playkuroundserver.domain.badge.application.BadgeService;
 import com.playkuround.playkuroundserver.domain.badge.dto.NewlyRegisteredBadge;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.score.application.TotalScoreService;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
@@ -25,6 +26,7 @@ public class AttendanceRegisterService {
     private final UserRepository userRepository;
     private final TotalScoreService totalScoreService;
     private final AttendanceRepository attendanceRepository;
+    private final DateTimeService dateTimeService;
     private final long attendanceScore = 10;
 
     @Transactional
@@ -52,13 +54,13 @@ public class AttendanceRegisterService {
     }
 
     private void validateDuplicateAttendance(User user) {
-        if (attendanceRepository.existsByUserAndCreatedAtAfter(user, LocalDate.now().atStartOfDay())) {
+        if (attendanceRepository.existsByUserAndAttendanceDateTimeAfter(user, LocalDate.now().atStartOfDay())) {
             throw new DuplicateAttendanceException();
         }
     }
 
     private void saveAttendance(User user, Location location) {
-        Attendance attendance = Attendance.of(user, location);
+        Attendance attendance = Attendance.of(user, location, dateTimeService.now());
         attendanceRepository.save(attendance);
     }
 

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchService.java
@@ -2,7 +2,6 @@ package com.playkuround.playkuroundserver.domain.attendance.application;
 
 import com.playkuround.playkuroundserver.domain.attendance.dao.AttendanceRepository;
 import com.playkuround.playkuroundserver.domain.attendance.domain.Attendance;
-import com.playkuround.playkuroundserver.domain.common.BaseTimeEntity;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,9 +20,9 @@ public class AttendanceSearchService {
     @Transactional(readOnly = true)
     public List<LocalDateTime> findAttendance(User user, int agoDays) {
         LocalDateTime monthAgo = LocalDate.now().minusMonths(agoDays).atStartOfDay();
-        List<Attendance> attendances = attendanceRepository.findByUserAndCreatedAtAfter(user, monthAgo);
+        List<Attendance> attendances = attendanceRepository.findByUserAndAttendanceDateTimeAfter(user, monthAgo);
         return attendances.stream()
-                .map(BaseTimeEntity::getCreatedAt)
+                .map(Attendance::getAttendanceDateTime)
                 .sorted()
                 .toList();
     }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchService.java
@@ -2,12 +2,12 @@ package com.playkuround.playkuroundserver.domain.attendance.application;
 
 import com.playkuround.playkuroundserver.domain.attendance.dao.AttendanceRepository;
 import com.playkuround.playkuroundserver.domain.attendance.domain.Attendance;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -16,10 +16,14 @@ import java.util.List;
 public class AttendanceSearchService {
 
     private final AttendanceRepository attendanceRepository;
+    private final DateTimeService dateTimeService;
 
     @Transactional(readOnly = true)
     public List<LocalDateTime> findAttendance(User user, int agoDays) {
-        LocalDateTime monthAgo = LocalDate.now().minusMonths(agoDays).atStartOfDay();
+        LocalDateTime monthAgo = dateTimeService.getLocalDateNow()
+                .minusMonths(agoDays)
+                .atStartOfDay();
+
         List<Attendance> attendances = attendanceRepository.findByUserAndAttendanceDateTimeAfter(user, monthAgo);
         return attendances.stream()
                 .map(Attendance::getAttendanceDateTime)

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/dao/AttendanceRepository.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/dao/AttendanceRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
-    List<Attendance> findByUserAndCreatedAtAfter(User user, LocalDateTime localDateTime);
+    List<Attendance> findByUserAndAttendanceDateTimeAfter(User user, LocalDateTime localDateTime);
 
-    boolean existsByUserAndCreatedAtAfter(User user, LocalDateTime localDateTime);
+    boolean existsByUserAndAttendanceDateTimeAfter(User user, LocalDateTime localDateTime);
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/attendance/domain/Attendance.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/attendance/domain/Attendance.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,13 +32,16 @@ public class Attendance extends BaseTimeEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
-    private Attendance(User user, double latitude, double longitude) {
+    private LocalDateTime attendanceDateTime;
+
+    private Attendance(User user, double latitude, double longitude, LocalDateTime attendanceDateTime) {
         this.user = user;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.attendanceDateTime = attendanceDateTime;
     }
 
-    public static Attendance of(User user, Location location) {
-        return new Attendance(user, location.latitude(), location.longitude());
+    public static Attendance of(User user, Location location, LocalDateTime attendanceDateTime) {
+        return new Attendance(user, location.latitude(), location.longitude(), attendanceDateTime);
     }
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailVerifyService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/auth/email/application/AuthEmailVerifyService.java
@@ -11,13 +11,12 @@ import com.playkuround.playkuroundserver.domain.auth.email.exception.NotMatchAut
 import com.playkuround.playkuroundserver.domain.auth.token.application.TokenService;
 import com.playkuround.playkuroundserver.domain.auth.token.domain.AuthVerifyToken;
 import com.playkuround.playkuroundserver.domain.auth.token.dto.TokenDto;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.user.application.UserLoginService;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +26,7 @@ public class AuthEmailVerifyService {
     private final UserRepository userRepository;
     private final UserLoginService userLoginService;
     private final AuthEmailRepository authEmailRepository;
+    private final DateTimeService dateTimeService;
 
     @Transactional
     public AuthVerifyEmailResult verifyAuthEmail(String code, String email) {
@@ -51,7 +51,7 @@ public class AuthEmailVerifyService {
         if (!authEmail.isValidate()) {
             throw new AuthEmailNotFoundException();
         }
-        if (authEmail.getExpiredAt().isBefore(LocalDateTime.now())) {
+        if (authEmail.getExpiredAt().isBefore(dateTimeService.getLocalDateTimeNow())) {
             throw new AuthCodeExpiredException();
         }
         if (!authEmail.getCode().equals(code)) {

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeService.java
@@ -8,6 +8,7 @@ import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.badge.domain.Badge;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.badge.dto.NewlyRegisteredBadge;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.landmark.domain.LandmarkType;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
@@ -27,6 +28,7 @@ public class BadgeService {
 
     private final UserRepository userRepository;
     private final BadgeRepository badgeRepository;
+    private final DateTimeService dateTimeService;
     private final CollegeSpecialBadgeFactory collegeSpecialBadgeFactory;
 
     @Transactional(readOnly = true)
@@ -51,7 +53,7 @@ public class BadgeService {
 
         // 기념일 기준 뱃지
         SpecialDayBadgeList.getSpecialDayBadges().stream()
-                .filter(specialDayBadge -> specialDayBadge.supports(userBadgeSet))
+                .filter(specialDayBadge -> specialDayBadge.supports(userBadgeSet, dateTimeService.now().toLocalDate()))
                 .forEach(specialDayBadge -> {
                     BadgeType badgeType = specialDayBadge.getBadgeType();
                     badgeRepository.save(Badge.createBadge(user, badgeType));

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeService.java
@@ -53,7 +53,7 @@ public class BadgeService {
 
         // 기념일 기준 뱃지
         SpecialDayBadgeList.getSpecialDayBadges().stream()
-                .filter(specialDayBadge -> specialDayBadge.supports(userBadgeSet, dateTimeService.now().toLocalDate()))
+                .filter(specialDayBadge -> specialDayBadge.supports(userBadgeSet, dateTimeService.getLocalDateNow()))
                 .forEach(specialDayBadge -> {
                     BadgeType badgeType = specialDayBadge.getBadgeType();
                     badgeRepository.save(Badge.createBadge(user, badgeType));

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/ArborDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/ArborDayBadge.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.badge.application.specialday_ba
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
+import java.time.LocalDate;
 import java.util.Set;
 
 public class ArborDayBadge implements SpecialDayBadge {
@@ -11,9 +12,9 @@ public class ArborDayBadge implements SpecialDayBadge {
     }
 
     @Override
-    public boolean supports(Set<BadgeType> userBadgeSet) {
+    public boolean supports(Set<BadgeType> userBadgeSet, LocalDate localDate) {
         BadgeType badgeType = getBadgeType();
-        return DateTimeUtils.isTodayArborDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isArborDay(localDate) && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/ChildrenDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/ChildrenDayBadge.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.badge.application.specialday_ba
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
+import java.time.LocalDate;
 import java.util.Set;
 
 public class ChildrenDayBadge implements SpecialDayBadge {
@@ -11,9 +12,9 @@ public class ChildrenDayBadge implements SpecialDayBadge {
     }
 
     @Override
-    public boolean supports(Set<BadgeType> userBadgeSet) {
+    public boolean supports(Set<BadgeType> userBadgeSet, LocalDate localDate) {
         BadgeType badgeType = getBadgeType();
-        return DateTimeUtils.isTodayChildrenDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isChildrenDay(localDate) && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/DuckDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/DuckDayBadge.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.badge.application.specialday_ba
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
+import java.time.LocalDate;
 import java.util.Set;
 
 public class DuckDayBadge implements SpecialDayBadge {
@@ -11,9 +12,9 @@ public class DuckDayBadge implements SpecialDayBadge {
     }
 
     @Override
-    public boolean supports(Set<BadgeType> userBadgeSet) {
+    public boolean supports(Set<BadgeType> userBadgeSet, LocalDate localDate) {
         BadgeType badgeType = getBadgeType();
-        return DateTimeUtils.isTodayDuckDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isDuckDay(localDate) && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/FoundationDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/FoundationDayBadge.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.badge.application.specialday_ba
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
+import java.time.LocalDate;
 import java.util.Set;
 
 public class FoundationDayBadge implements SpecialDayBadge {
@@ -11,9 +12,9 @@ public class FoundationDayBadge implements SpecialDayBadge {
     }
 
     @Override
-    public boolean supports(Set<BadgeType> userBadgeSet) {
+    public boolean supports(Set<BadgeType> userBadgeSet, LocalDate localDate) {
         BadgeType badgeType = getBadgeType();
-        return DateTimeUtils.isTodayFoundationDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isFoundationDay(localDate) && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/SpecialDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/SpecialDayBadge.java
@@ -2,11 +2,12 @@ package com.playkuround.playkuroundserver.domain.badge.application.specialday_ba
 
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 
+import java.time.LocalDate;
 import java.util.Set;
 
 public interface SpecialDayBadge {
 
-    boolean supports(Set<BadgeType> userBadgeSet);
+    boolean supports(Set<BadgeType> userBadgeSet, LocalDate localDate);
 
     BadgeType getBadgeType();
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/WhiteDayBadge.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/badge/application/specialday_badge/WhiteDayBadge.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.badge.application.specialday_ba
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.global.util.DateTimeUtils;
 
+import java.time.LocalDate;
 import java.util.Set;
 
 public class WhiteDayBadge implements SpecialDayBadge {
@@ -11,9 +12,9 @@ public class WhiteDayBadge implements SpecialDayBadge {
     }
 
     @Override
-    public boolean supports(Set<BadgeType> userBadgeSet) {
+    public boolean supports(Set<BadgeType> userBadgeSet, LocalDate localDate) {
         BadgeType badgeType = getBadgeType();
-        return DateTimeUtils.isTodayWhiteDay() && !userBadgeSet.contains(badgeType);
+        return DateTimeUtils.isWhiteDay(localDate) && !userBadgeSet.contains(badgeType);
     }
 
     @Override

--- a/src/main/java/com/playkuround/playkuroundserver/domain/common/DateTimeService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/common/DateTimeService.java
@@ -1,0 +1,14 @@
+package com.playkuround.playkuroundserver.domain.common;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class DateTimeService {
+
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/playkuround/playkuroundserver/domain/common/DateTimeService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/common/DateTimeService.java
@@ -2,13 +2,18 @@ package com.playkuround.playkuroundserver.domain.common;
 
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Component
 public class DateTimeService {
 
-    public LocalDateTime now() {
+    public LocalDateTime getLocalDateTimeNow() {
         return LocalDateTime.now();
+    }
+
+    public LocalDate getLocalDateNow() {
+        return LocalDate.now();
     }
 
 }

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankService.java
@@ -24,7 +24,7 @@ public class LandmarkRankService {
     @Transactional(readOnly = true)
     public ScoreRankingResponse getRankTop100ByLandmark(User user, Long landmarkId) {
         ScoreRankingResponse response = ScoreRankingResponse.createEmptyResponse();
-        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime(dateTimeService.now().toLocalDate());
+        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime(dateTimeService.getLocalDateNow());
 
         List<NicknameAndScore> nicknameAndScores = adventureRepository.findRankTop100DescByLandmarkId(landmarkId, monthStartDateTime);
         nicknameAndScores.forEach(nicknameAndScore ->

--- a/src/main/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankService.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankService.java
@@ -1,6 +1,7 @@
 package com.playkuround.playkuroundserver.domain.score.application;
 
 import com.playkuround.playkuroundserver.domain.adventure.dao.AdventureRepository;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.score.dto.NicknameAndScore;
 import com.playkuround.playkuroundserver.domain.score.dto.RankAndScore;
 import com.playkuround.playkuroundserver.domain.score.dto.response.ScoreRankingResponse;
@@ -18,11 +19,12 @@ import java.util.List;
 public class LandmarkRankService {
 
     private final AdventureRepository adventureRepository;
+    private final DateTimeService dateTimeService;
 
     @Transactional(readOnly = true)
     public ScoreRankingResponse getRankTop100ByLandmark(User user, Long landmarkId) {
         ScoreRankingResponse response = ScoreRankingResponse.createEmptyResponse();
-        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime();
+        LocalDateTime monthStartDateTime = DateTimeUtils.getMonthStartDateTime(dateTimeService.now().toLocalDate());
 
         List<NicknameAndScore> nicknameAndScores = adventureRepository.findRankTop100DescByLandmarkId(landmarkId, monthStartDateTime);
         nicknameAndScores.forEach(nicknameAndScore ->

--- a/src/main/java/com/playkuround/playkuroundserver/global/util/DateTimeUtils.java
+++ b/src/main/java/com/playkuround/playkuroundserver/global/util/DateTimeUtils.java
@@ -8,34 +8,28 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class DateTimeUtils {
 
-    public static LocalDateTime getMonthStartDateTime() {
-        LocalDate today = LocalDate.now();
-        return today.withDayOfMonth(1).atStartOfDay();
+    public static LocalDateTime getMonthStartDateTime(LocalDate localDate) {
+        return localDate.withDayOfMonth(1).atStartOfDay();
     }
 
-    public static boolean isTodayFoundationDay() {
-        LocalDate today = LocalDate.now();
-        return today.getMonth().getValue() == 5 && today.getDayOfMonth() == 15;
+    public static boolean isFoundationDay(LocalDate localDate) {
+        return localDate.getMonth().getValue() == 5 && localDate.getDayOfMonth() == 15;
     }
 
-    public static boolean isTodayArborDay() {
-        LocalDate today = LocalDate.now();
-        return today.getMonth().getValue() == 4 && today.getDayOfMonth() == 5;
+    public static boolean isArborDay(LocalDate localDate) {
+        return localDate.getMonth().getValue() == 4 && localDate.getDayOfMonth() == 5;
     }
 
-    public static boolean isTodayChildrenDay() {
-        LocalDate today = LocalDate.now();
-        return today.getMonth().getValue() == 5 && today.getDayOfMonth() == 5;
+    public static boolean isChildrenDay(LocalDate localDate) {
+        return localDate.getMonth().getValue() == 5 && localDate.getDayOfMonth() == 5;
     }
 
-    public static boolean isTodayWhiteDay() {
-        LocalDate today = LocalDate.now();
-        return today.getMonth().getValue() == 3 && today.getDayOfMonth() == 14;
+    public static boolean isWhiteDay(LocalDate localDate) {
+        return localDate.getMonth().getValue() == 3 && localDate.getDayOfMonth() == 14;
     }
 
-    public static boolean isTodayDuckDay() {
-        LocalDate today = LocalDate.now();
-        return today.getMonth().getValue() == 5 && today.getDayOfMonth() == 2;
+    public static boolean isDuckDay(LocalDate localDate) {
+        return localDate.getMonth().getValue() == 5 && localDate.getDayOfMonth() == 2;
     }
 
 }

--- a/src/test/java/com/playkuround/playkuroundserver/domain/attendance/api/AttendanceApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/attendance/api/AttendanceApiTest.java
@@ -10,6 +10,7 @@ import com.playkuround.playkuroundserver.domain.attendance.domain.Attendance;
 import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.badge.domain.Badge;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.error.ErrorCode;
@@ -19,12 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.data.auditing.AuditingHandler;
-import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.http.MediaType;
@@ -35,10 +31,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -62,6 +57,9 @@ class AttendanceApiTest {
 
     @Autowired
     private AttendanceRepository attendanceRepository;
+
+    @Autowired
+    private DateTimeService dateTimeService;
 
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
@@ -91,8 +89,7 @@ class AttendanceApiTest {
             // expected
             mockMvc.perform(post("/api/attendances")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(request)
-                    )
+                            .content(request))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.isSuccess").value(true))
                     .andExpect(jsonPath("$.response.newBadges.size()").value(1))
@@ -104,13 +101,14 @@ class AttendanceApiTest {
             assertThat(user.getAttendanceDays()).isEqualTo(1);
 
             List<Badge> badges = badgeRepository.findAll();
-            assertThat(badges.size()).isEqualTo(1);
-            assertThat(badges.get(0).getUser().getId()).isEqualTo(user.getId());
-            assertThat(badges.get(0).getBadgeType()).isEqualTo(BadgeType.ATTENDANCE_1);
+            assertThat(badges).hasSize(1)
+                    .extracting("user.id", "badgeType")
+                    .containsExactly(tuple(user.getId(), BadgeType.ATTENDANCE_1));
 
             List<Attendance> attendances = attendanceRepository.findAll();
-            assertThat(attendances.size()).isEqualTo(1);
-            assertThat(attendances.get(0).getUser().getId()).isEqualTo(user.getId());
+            assertThat(attendances).hasSize(1)
+                    .extracting("user.id")
+                    .containsExactly(user.getId());
 
             ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();
             Double myTotalScore = zSetOperations.score(redisSetKey, user.getEmail());
@@ -124,7 +122,7 @@ class AttendanceApiTest {
             // TODO : 12시 넘어가는 시점에는 테스트가 실패함
             // given
             User user = userRepository.findAll().get(0);
-            attendanceRepository.save(Attendance.of(user, new Location(37.539927, 127.073006)));
+            attendanceRepository.save(Attendance.of(user, new Location(37.539927, 127.073006), dateTimeService.now()));
 
             AttendanceRegisterRequest attendanceRegisterRequest = new AttendanceRegisterRequest(37.539927, 127.073006);
             String request = objectMapper.writeValueAsString(attendanceRegisterRequest);
@@ -132,14 +130,16 @@ class AttendanceApiTest {
             // expected
             mockMvc.perform(post("/api/attendances")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(request)
-                    )
+                            .content(request))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.isSuccess").value(false))
                     .andExpect(jsonPath("$.errorResponse.code").value(ErrorCode.DUPLICATE_ATTENDANCE.getCode()))
                     .andExpect(jsonPath("$.errorResponse.message").value(ErrorCode.DUPLICATE_ATTENDANCE.getMessage()))
                     .andExpect(jsonPath("$.errorResponse.status").value(ErrorCode.DUPLICATE_ATTENDANCE.getStatus().value()))
                     .andDo(print());
+
+            List<Attendance> attendances = attendanceRepository.findAll();
+            assertThat(attendances).hasSize(1);
         }
 
         @Test
@@ -153,14 +153,16 @@ class AttendanceApiTest {
             // expected
             mockMvc.perform(post("/api/attendances")
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(request)
-                    )
+                            .content(request))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.isSuccess").value(false))
                     .andExpect(jsonPath("$.errorResponse.code").value(ErrorCode.INVALID_LOCATION_KU.getCode()))
                     .andExpect(jsonPath("$.errorResponse.message").value(ErrorCode.INVALID_LOCATION_KU.getMessage()))
                     .andExpect(jsonPath("$.errorResponse.status").value(ErrorCode.INVALID_LOCATION_KU.getStatus().value()))
                     .andDo(print());
+
+            List<Attendance> attendances = attendanceRepository.findAll();
+            assertThat(attendances).isEmpty();
         }
     }
 
@@ -168,12 +170,6 @@ class AttendanceApiTest {
     @Nested
     @DisplayName("출석 조회하기")
     class searchAttendance {
-
-        @MockBean
-        private DateTimeProvider dateTimeProvider;
-
-        @SpyBean
-        private AuditingHandler auditingHandler;
 
         @Autowired
         private AttendanceRegisterService attendanceRegisterService;
@@ -184,8 +180,6 @@ class AttendanceApiTest {
         void attendanceSearch() throws Exception {
             // TODO : need refactoring
             // given
-            MockitoAnnotations.openMocks(this);
-            auditingHandler.setDateTimeProvider(dateTimeProvider);
 
             User user = userRepository.findAll().get(0);
             Location location = new Location(37.539927, 127.073006);
@@ -197,8 +191,7 @@ class AttendanceApiTest {
                 String formatDate = thatLocalDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
                 dateList.add(formatDate);
 
-                when(dateTimeProvider.getNow()).thenReturn(Optional.of(thatLocalDateTime));
-                attendanceRegisterService.registerAttendance(user, location);
+                attendanceRepository.save(Attendance.of(user, location, thatLocalDateTime));
             }
 
             // expected
@@ -209,8 +202,7 @@ class AttendanceApiTest {
                     .andReturn();
             String json = mvcResult.getResponse().getContentAsString();
             List<String> target = JsonPath.parse(json).read("$.response.attendances");
-
-            assertThat(dateList).isEqualTo(target);
+            assertThat(target).isEqualTo(dateList);
         }
     }
 }

--- a/src/test/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,9 +56,8 @@ class AttendanceRegisterServiceTest {
         // given
         when(attendanceRepository.existsByUserAndAttendanceDateTimeAfter(any(User.class), any(LocalDateTime.class)))
                 .thenReturn(false);
-
-        when(dateTimeService.now())
-                .thenReturn(LocalDateTime.of(2024, 6, 30, 0, 0));
+        when(dateTimeService.getLocalDateNow())
+                .thenReturn(LocalDate.of(2024, 6, 30));
 
         NewlyRegisteredBadge newlyRegisteredBadge = new NewlyRegisteredBadge();
         newlyRegisteredBadge.addBadge(BadgeType.ATTENDANCE_1);
@@ -65,9 +65,10 @@ class AttendanceRegisterServiceTest {
         when(badgeService.updateNewlyAttendanceBadges(any(User.class)))
                 .thenReturn(newlyRegisteredBadge);
 
-        // when
         User user = TestUtil.createUser();
         Location location = new Location(37.539927, 127.073006);
+
+        // when
         NewlyRegisteredBadge result = attendanceRegisterService.registerAttendance(user, location);
 
         // then
@@ -86,9 +87,11 @@ class AttendanceRegisterServiceTest {
     @Test
     @DisplayName("출석 범위에 벗어나면 에러가 발생한다")
     void registerAttendance_2() {
-        // expect
+        // given
         User user = TestUtil.createUser();
         Location location = new Location(0.0, 0.0);
+
+        // expect
         assertThatThrownBy(() -> attendanceRegisterService.registerAttendance(user, location))
                 .isInstanceOf(InvalidAttendanceLocationException.class);
     }
@@ -99,10 +102,12 @@ class AttendanceRegisterServiceTest {
         // given
         when(attendanceRepository.existsByUserAndAttendanceDateTimeAfter(any(User.class), any(LocalDateTime.class)))
                 .thenReturn(true);
-
-        // expect
+        when(dateTimeService.getLocalDateNow())
+                .thenReturn(LocalDate.of(2024, 6, 30));
         User user = TestUtil.createUser();
         Location location = new Location(37.539927, 127.073006);
+
+        // expect
         assertThatThrownBy(() -> attendanceRegisterService.registerAttendance(user, location))
                 .isInstanceOf(DuplicateAttendanceException.class);
     }

--- a/src/test/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceRegisterServiceTest.java
@@ -8,6 +8,7 @@ import com.playkuround.playkuroundserver.domain.attendance.exception.InvalidAtte
 import com.playkuround.playkuroundserver.domain.badge.application.BadgeService;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.badge.dto.NewlyRegisteredBadge;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.score.application.TotalScoreService;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
@@ -45,12 +46,18 @@ class AttendanceRegisterServiceTest {
     @Mock
     private TotalScoreService totalScoreService;
 
+    @Mock
+    private DateTimeService dateTimeService;
+
     @Test
     @DisplayName("출석 시 뱃지와 출석정보가 저장되고 유저의 출석횟수가 증가한다")
     void registerAttendance_1() {
         // given
-        when(attendanceRepository.existsByUserAndCreatedAtAfter(any(User.class), any(LocalDateTime.class)))
+        when(attendanceRepository.existsByUserAndAttendanceDateTimeAfter(any(User.class), any(LocalDateTime.class)))
                 .thenReturn(false);
+
+        when(dateTimeService.now())
+                .thenReturn(LocalDateTime.of(2024, 6, 30, 0, 0));
 
         NewlyRegisteredBadge newlyRegisteredBadge = new NewlyRegisteredBadge();
         newlyRegisteredBadge.addBadge(BadgeType.ATTENDANCE_1);
@@ -90,7 +97,7 @@ class AttendanceRegisterServiceTest {
     @DisplayName("출석은 하루에 한번만 가능하다")
     void registerAttendance_3() {
         // given
-        when(attendanceRepository.existsByUserAndCreatedAtAfter(any(User.class), any(LocalDateTime.class)))
+        when(attendanceRepository.existsByUserAndAttendanceDateTimeAfter(any(User.class), any(LocalDateTime.class)))
                 .thenReturn(true);
 
         // expect

--- a/src/test/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchServiceTest.java
@@ -3,6 +3,7 @@ package com.playkuround.playkuroundserver.domain.attendance.application;
 import com.playkuround.playkuroundserver.TestUtil;
 import com.playkuround.playkuroundserver.domain.attendance.dao.AttendanceRepository;
 import com.playkuround.playkuroundserver.domain.attendance.domain.Attendance;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
 import com.playkuround.playkuroundserver.global.util.Location;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,12 +33,18 @@ class AttendanceSearchServiceTest {
     @Mock
     private AttendanceRepository attendanceRepository;
 
+    @Mock
+    private DateTimeService dateTimeService;
+
     @Test
     @DisplayName("한달동안의 출석정보가 정렬되어 반환된다")
     void findAttendanceForMonth_1() {
         // given
+        when(dateTimeService.getLocalDateNow())
+                .thenReturn(LocalDate.of(2024, 7, 1));
+
         Random random = new Random();
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.of(2024, 7, 1, 0, 0);
         User user = TestUtil.createUser();
         Location location = new Location(37.539927, 127.073006);
 
@@ -49,13 +57,13 @@ class AttendanceSearchServiceTest {
                 .sorted()
                 .forEach(x -> {
                     Attendance attendance = Attendance.of(user, location, now.plusDays(x));
-                    //ReflectionTestUtils.setField(attendance, "createdAt", now.plusDays(x));
 
                     attendances.add(attendance);
                     expected.add(attendance.getAttendanceDateTime());
                 });
         when(attendanceRepository.findByUserAndAttendanceDateTimeAfter(any(User.class), any(LocalDateTime.class)))
                 .thenReturn(attendances);
+
 
         // when
         List<LocalDateTime> result = attendanceSearchService.findAttendance(user, 30);
@@ -68,6 +76,8 @@ class AttendanceSearchServiceTest {
     @DisplayName("출석정보가 없으면 빈리스트가 반환된다")
     void findAttendanceForMonth_2() {
         // given
+        when(dateTimeService.getLocalDateNow())
+                .thenReturn(LocalDate.of(2024, 7, 1));
         when(attendanceRepository.findByUserAndAttendanceDateTimeAfter(any(User.class), any(LocalDateTime.class)))
                 .thenReturn(new ArrayList<>());
 

--- a/src/test/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/attendance/application/AttendanceSearchServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -49,13 +48,13 @@ class AttendanceSearchServiceTest {
                 .distinct()
                 .sorted()
                 .forEach(x -> {
-                    Attendance attendance = Attendance.of(user, location);
-                    ReflectionTestUtils.setField(attendance, "createdAt", now.plusDays(x));
+                    Attendance attendance = Attendance.of(user, location, now.plusDays(x));
+                    //ReflectionTestUtils.setField(attendance, "createdAt", now.plusDays(x));
 
                     attendances.add(attendance);
-                    expected.add(attendance.getCreatedAt());
+                    expected.add(attendance.getAttendanceDateTime());
                 });
-        when(attendanceRepository.findByUserAndCreatedAtAfter(any(User.class), any(LocalDateTime.class)))
+        when(attendanceRepository.findByUserAndAttendanceDateTimeAfter(any(User.class), any(LocalDateTime.class)))
                 .thenReturn(attendances);
 
         // when
@@ -69,7 +68,7 @@ class AttendanceSearchServiceTest {
     @DisplayName("출석정보가 없으면 빈리스트가 반환된다")
     void findAttendanceForMonth_2() {
         // given
-        when(attendanceRepository.findByUserAndCreatedAtAfter(any(User.class), any(LocalDateTime.class)))
+        when(attendanceRepository.findByUserAndAttendanceDateTimeAfter(any(User.class), any(LocalDateTime.class)))
                 .thenReturn(new ArrayList<>());
 
         // when

--- a/src/test/java/com/playkuround/playkuroundserver/domain/auth/email/api/AuthEmailSendApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/auth/email/api/AuthEmailSendApiTest.java
@@ -27,8 +27,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -62,8 +60,6 @@ class AuthEmailSendApiTest {
     @DisplayName("이메일 인증 전송 성공")
     void sendAuthEmailSuccess() throws Exception {
         // given
-        doNothing().when(emailService).sendMail(any());
-
         String email = "test@konkuk.ac.kr";
         AuthEmailSendRequest attendanceRegisterRequest = new AuthEmailSendRequest(email);
         String request = objectMapper.writeValueAsString(attendanceRegisterRequest);
@@ -71,8 +67,7 @@ class AuthEmailSendApiTest {
         // expected
         MvcResult mvcResult = mockMvc.perform(post("/api/auth/emails")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(request)
-                )
+                        .content(request))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.response.expireAt").exists())

--- a/src/test/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeServiceTest.java
@@ -30,7 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -135,8 +135,10 @@ class BadgeServiceTest {
             for (int i = 0; i < attendanceDay; i++) {
                 user.increaseAttendanceDay();
             }
-            when(badgeRepository.findByUser(user)).thenReturn(new ArrayList<>());
-            when(dateTimeService.now()).thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
+            when(badgeRepository.findByUser(user))
+                    .thenReturn(new ArrayList<>());
+            when(dateTimeService.getLocalDateNow())
+                    .thenReturn(LocalDate.of(2024, 7, 1));
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
             try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
@@ -163,8 +165,10 @@ class BadgeServiceTest {
         void success_2() {
             // given
             User user = TestUtil.createUser();
-            when(badgeRepository.findByUser(user)).thenReturn(new ArrayList<>());
-            when(dateTimeService.now()).thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
+            when(badgeRepository.findByUser(user))
+                    .thenReturn(new ArrayList<>());
+            when(dateTimeService.getLocalDateNow())
+                    .thenReturn(LocalDate.of(2024, 7, 1));
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
             try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
@@ -198,7 +202,8 @@ class BadgeServiceTest {
                             new Badge(user, BadgeType.ATTENDANCE_10),
                             new Badge(user, BadgeType.ATTENDANCE_CHILDREN_DAY)
                     ));
-            when(dateTimeService.now()).thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
+            when(dateTimeService.getLocalDateNow())
+                    .thenReturn(LocalDate.of(2024, 7, 1));
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
             try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
@@ -281,12 +286,13 @@ class BadgeServiceTest {
             when(collegeSpecialBadgeFactory.getBadgeType(any(User.class), any(Set.class), any(Landmark.class)))
                     .thenReturn(Optional.empty());
 
-            // when
             Landmark landmark = createLandmark(landmarkType);
+
+            // when
             NewlyRegisteredBadge newlyRegisteredBadge = badgeService.updateNewlyAdventureBadges(user, landmark);
-            List<NewlyRegisteredBadge.BadgeInfo> result = newlyRegisteredBadge.getNewlyBadges();
 
             // then
+            List<NewlyRegisteredBadge.BadgeInfo> result = newlyRegisteredBadge.getNewlyBadges();
             List<String> target = result.stream()
                     .map(NewlyRegisteredBadge.BadgeInfo::name)
                     .toList();
@@ -303,12 +309,13 @@ class BadgeServiceTest {
             when(collegeSpecialBadgeFactory.getBadgeType(any(User.class), any(Set.class), any(Landmark.class)))
                     .thenReturn(Optional.of(BadgeType.COLLEGE_OF_ENGINEERING_A));
 
-            // when
             Landmark landmark = createLandmark(LandmarkType.공학관A);
+
+            // when
             NewlyRegisteredBadge newlyRegisteredBadge = badgeService.updateNewlyAdventureBadges(user, landmark);
-            List<NewlyRegisteredBadge.BadgeInfo> result = newlyRegisteredBadge.getNewlyBadges();
 
             // then
+            List<NewlyRegisteredBadge.BadgeInfo> result = newlyRegisteredBadge.getNewlyBadges();
             List<String> target = result.stream()
                     .map(NewlyRegisteredBadge.BadgeInfo::name)
                     .toList();

--- a/src/test/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/badge/application/BadgeServiceTest.java
@@ -6,6 +6,7 @@ import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.badge.domain.Badge;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.badge.dto.NewlyRegisteredBadge;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
 import com.playkuround.playkuroundserver.domain.landmark.domain.LandmarkType;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
@@ -29,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +55,9 @@ class BadgeServiceTest {
 
     @Mock
     private CollegeSpecialBadgeFactory collegeSpecialBadgeFactory;
+
+    @Mock
+    private DateTimeService dateTimeService;
 
     @Nested
     @DisplayName("뱃지 조회하기")
@@ -131,14 +136,15 @@ class BadgeServiceTest {
                 user.increaseAttendanceDay();
             }
             when(badgeRepository.findByUser(user)).thenReturn(new ArrayList<>());
+            when(dateTimeService.now()).thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
             try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
-                mockedStatic.when(DateTimeUtils::isTodayDuckDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayArborDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayWhiteDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayChildrenDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayFoundationDay).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isDuckDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isArborDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isWhiteDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isChildrenDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isFoundationDay(any())).thenReturn(false);
 
                 // when
                 NewlyRegisteredBadge newlyRegisteredBadge = badgeService.updateNewlyAttendanceBadges(user);
@@ -158,14 +164,15 @@ class BadgeServiceTest {
             // given
             User user = TestUtil.createUser();
             when(badgeRepository.findByUser(user)).thenReturn(new ArrayList<>());
+            when(dateTimeService.now()).thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
             try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
-                mockedStatic.when(DateTimeUtils::isTodayDuckDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayArborDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayWhiteDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayChildrenDay).thenReturn(true);
-                mockedStatic.when(DateTimeUtils::isTodayFoundationDay).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isDuckDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isArborDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isWhiteDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isChildrenDay(any())).thenReturn(true);
+                mockedStatic.when(() -> DateTimeUtils.isFoundationDay(any())).thenReturn(false);
 
                 // when
                 NewlyRegisteredBadge newlyRegisteredBadge = badgeService.updateNewlyAttendanceBadges(user);
@@ -191,14 +198,15 @@ class BadgeServiceTest {
                             new Badge(user, BadgeType.ATTENDANCE_10),
                             new Badge(user, BadgeType.ATTENDANCE_CHILDREN_DAY)
                     ));
+            when(dateTimeService.now()).thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
 
             List<NewlyRegisteredBadge.BadgeInfo> result;
             try (MockedStatic<DateTimeUtils> mockedStatic = Mockito.mockStatic(DateTimeUtils.class)) {
-                mockedStatic.when(DateTimeUtils::isTodayDuckDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayWhiteDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayArborDay).thenReturn(false);
-                mockedStatic.when(DateTimeUtils::isTodayChildrenDay).thenReturn(true);
-                mockedStatic.when(DateTimeUtils::isTodayFoundationDay).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isDuckDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isArborDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isWhiteDay(any())).thenReturn(false);
+                mockedStatic.when(() -> DateTimeUtils.isChildrenDay(any())).thenReturn(true);
+                mockedStatic.when(() -> DateTimeUtils.isFoundationDay(any())).thenReturn(false);
 
                 // when
                 NewlyRegisteredBadge newlyRegisteredBadge = badgeService.updateNewlyAttendanceBadges(user);

--- a/src/test/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -43,8 +44,8 @@ class LandmarkRankServiceTest {
                 .thenReturn(List.of());
         when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.empty());
-        when(dateTimeService.now())
-                .thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
+        when(dateTimeService.getLocalDateNow())
+                .thenReturn(LocalDate.of(2024, 7, 1));
 
         // when
         User user = TestUtil.createUser();
@@ -67,8 +68,8 @@ class LandmarkRankServiceTest {
                 .thenReturn(nicknameAndScores);
         when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.empty());
-        when(dateTimeService.now())
-                .thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
+        when(dateTimeService.getLocalDateNow())
+                .thenReturn(LocalDate.of(2024, 7, 1));
 
         // when
         User user = TestUtil.createUser();
@@ -97,8 +98,8 @@ class LandmarkRankServiceTest {
                 .thenReturn(nicknameAndScores);
         when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.of(new RankAndScore(14, 37)));
-        when(dateTimeService.now())
-                .thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
+        when(dateTimeService.getLocalDateNow())
+                .thenReturn(LocalDate.of(2024, 7, 1));
 
         // when
         User user = TestUtil.createUser();
@@ -126,8 +127,8 @@ class LandmarkRankServiceTest {
                 .thenReturn(nicknameAndScores);
         when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.of(new RankAndScore(40, 62)));
-        when(dateTimeService.now())
-                .thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
+        when(dateTimeService.getLocalDateNow())
+                .thenReturn(LocalDate.of(2024, 7, 1));
 
         // when
         User user = TestUtil.createUser();

--- a/src/test/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankServiceTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/score/application/LandmarkRankServiceTest.java
@@ -2,6 +2,7 @@ package com.playkuround.playkuroundserver.domain.score.application;
 
 import com.playkuround.playkuroundserver.TestUtil;
 import com.playkuround.playkuroundserver.domain.adventure.dao.AdventureRepository;
+import com.playkuround.playkuroundserver.domain.common.DateTimeService;
 import com.playkuround.playkuroundserver.domain.score.dto.NicknameAndScore;
 import com.playkuround.playkuroundserver.domain.score.dto.RankAndScore;
 import com.playkuround.playkuroundserver.domain.score.dto.response.ScoreRankingResponse;
@@ -31,6 +32,9 @@ class LandmarkRankServiceTest {
     @Mock
     private AdventureRepository adventureRepository;
 
+    @Mock
+    private DateTimeService dateTimeService;
+
     @Test
     @DisplayName("랭킹 유저가 한명도 없을 때")
     void getRankTop100ByLandmark1() {
@@ -39,6 +43,8 @@ class LandmarkRankServiceTest {
                 .thenReturn(List.of());
         when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.empty());
+        when(dateTimeService.now())
+                .thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
 
         // when
         User user = TestUtil.createUser();
@@ -61,6 +67,8 @@ class LandmarkRankServiceTest {
                 .thenReturn(nicknameAndScores);
         when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.empty());
+        when(dateTimeService.now())
+                .thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
 
         // when
         User user = TestUtil.createUser();
@@ -89,6 +97,8 @@ class LandmarkRankServiceTest {
                 .thenReturn(nicknameAndScores);
         when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.of(new RankAndScore(14, 37)));
+        when(dateTimeService.now())
+                .thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
 
         // when
         User user = TestUtil.createUser();
@@ -116,6 +126,8 @@ class LandmarkRankServiceTest {
                 .thenReturn(nicknameAndScores);
         when(adventureRepository.findMyRankByLandmarkId(any(User.class), any(Long.class), any(LocalDateTime.class)))
                 .thenReturn(Optional.of(new RankAndScore(40, 62)));
+        when(dateTimeService.now())
+                .thenReturn(LocalDateTime.of(2024, 7, 1, 0, 0));
 
         // when
         User user = TestUtil.createUser();


### PR DESCRIPTION
- LocalDateTime.now() 또는 LocalDate.now()를 직접 사용할 시 테스트하기 어려운 코드가 되기 때문에, Mocking이 가능하도록 중간 컴포넌트를 추가
```java
// before
LocalDateTime now = LocalDateTime.now();

// after
@Autowired
private DateTimeService;

LocalDateTime now = DateTimeService.getLocalDateTimeNow();
```

- 출석 날짜, 시각 정보를 `JpaAuditing` 에 기반하여 판단했었음. mocking이 가능하지만 테스트 코드가 복잡해지고 읽기 어려운 코드가 되므로, 별도의 필드를 추가하여 사용