### PR TITLE
refactor: landmark initial data in test case

### DIFF
--- a/src/main/java/com/playkuround/playkuroundserver/domain/landmark/domain/Landmark.java
+++ b/src/main/java/com/playkuround/playkuroundserver/domain/landmark/domain/Landmark.java
@@ -36,6 +36,15 @@ public class Landmark {
 
     private long highestScore;
 
+    public Landmark(LandmarkType landmarkType, double latitude, double longitude, int recognitionRadius) {
+        this.name = landmarkType;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.recognitionRadius = recognitionRadius;
+        this.firstUser = null;
+        this.highestScore = 0;
+    }
+
     public void updateFirstUser(User user, long score) {
         if (score == 0) return;
         if (firstUser == null || this.highestScore < score) {

--- a/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/adventure/api/AdventureApiTest.java
@@ -9,6 +9,7 @@ import com.playkuround.playkuroundserver.domain.badge.dao.BadgeRepository;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
+import com.playkuround.playkuroundserver.domain.landmark.domain.LandmarkType;
 import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
 import com.playkuround.playkuroundserver.domain.user.domain.User;
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -34,7 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationControllerTest
-@Sql(scripts = {"/data-mysql.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class AdventureApiTest {
 
     @Autowired
@@ -74,7 +73,8 @@ class AdventureApiTest {
     @DisplayName("탐험을 하게 되면 total score 증가, adventure 저장, 랜드마크별 최고기록과 유저별 게임 최고기록이 업데이트 된다.")
     void saveAdventure_1() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(3L).get();
+        Landmark landmark = new Landmark(LandmarkType.수의학관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
 
         AdventureSaveRequest adventureSaveRequest
                 = new AdventureSaveRequest(landmark.getId(), landmark.getLatitude(), landmark.getLongitude(), 100L, ScoreType.BOOK.name());
@@ -116,7 +116,8 @@ class AdventureApiTest {
     @DisplayName("랜드마크가 존재하지 않으면 에러가 발생한다.")
     void saveAdventure_2() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(3L).get();
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
 
         AdventureSaveRequest adventureSaveRequest
                 = new AdventureSaveRequest(-1L, landmark.getLatitude(), landmark.getLongitude(), 100L, ScoreType.BOOK.name());
@@ -141,7 +142,8 @@ class AdventureApiTest {
     @DisplayName("인식 거리 밖에 있으면 에러가 발생한다.")
     void saveAdventure_3() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(3L).get();
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
 
         AdventureSaveRequest adventureSaveRequest
                 = new AdventureSaveRequest(landmark.getId(), 0.0, 0.0, 100L, ScoreType.BOOK.name());
@@ -167,7 +169,8 @@ class AdventureApiTest {
     @DisplayName("정상적인 ScoreType이 아니면 에러가 발생한다.")
     void saveAdventure_4() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(3L).get();
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
 
         AdventureSaveRequest adventureSaveRequest
                 = new AdventureSaveRequest(landmark.getId(), landmark.getLatitude(), landmark.getLongitude(), 100L, "notFound");

--- a/src/test/java/com/playkuround/playkuroundserver/domain/landmark/api/LandmarkApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/landmark/api/LandmarkApiTest.java
@@ -34,6 +34,7 @@ class LandmarkApiTest {
 
     @AfterEach
     void clear() {
+        landmarkRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
     }
 
@@ -45,38 +46,48 @@ class LandmarkApiTest {
         @Test
         @DisplayName("위치 완전 동일")
         void success_1() throws Exception {
+            // given
+            Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+            landmarkRepository.save(landmark);
+
+            // expected
             mockMvc.perform(get("/api/landmarks")
-                            .param("latitude", "37.542602")
-                            .param("longitude", "127.078250")
-                    )
+                            .param("latitude", String.valueOf(landmark.getLatitude()))
+                            .param("longitude", String.valueOf(landmark.getLongitude())))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.response.distance").value(0.0))
-                    .andExpect(jsonPath("$.response.landmarkId").value(19))
-                    .andExpect(jsonPath("$.response.name").value(LandmarkType.인문학관.name()))
+                    .andExpect(jsonPath("$.response.landmarkId").value(landmark.getId()))
+                    .andExpect(jsonPath("$.response.name").value(landmark.getName().name()))
                     .andDo(print());
         }
 
         @Test
         @DisplayName("허용 범위 내에서 조회")
         void success_2() throws Exception {
+            // given
+            Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 1000);
+            landmarkRepository.save(landmark);
+
+            // expected
             mockMvc.perform(get("/api/landmarks")
-                            .param("latitude", "37.542600")
-                            .param("longitude", "127.078200")
-                    )
+                            .param("latitude", String.valueOf(landmark.getLatitude() + 0.0001))
+                            .param("longitude", String.valueOf(landmark.getLongitude())))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.response.landmarkId").value(19))
-                    .andExpect(jsonPath("$.response.name").value(LandmarkType.인문학관.name()))
-                    .andExpect(jsonPath("$.response.distance").value(4.4130028352636055))
+                    .andExpect(jsonPath("$.response.landmarkId").value(landmark.getId()))
+                    .andExpect(jsonPath("$.response.name").value(landmark.getName().name()))
                     .andDo(print());
         }
 
         @Test
         @DisplayName("허용 범위 밖에서 조회")
         void success_3() throws Exception {
+            // given
+            Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+            landmarkRepository.save(landmark);
+
+            // expected
             mockMvc.perform(get("/api/landmarks")
                             .param("latitude", "13")
-                            .param("longitude", "13")
-                    )
+                            .param("longitude", "13"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.response").isEmpty())
                     .andDo(print());
@@ -96,28 +107,29 @@ class LandmarkApiTest {
             user.updateProfileBadge(BadgeType.ATTENDANCE_50);
             userRepository.save(user);
 
-            Landmark landmark = landmarkRepository.findById(1L).get();
-            landmark.updateFirstUser(user, 1000);
+            long score = 1000;
+            Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+            landmark.updateFirstUser(user, score);
             landmarkRepository.save(landmark);
 
             // expected
-            mockMvc.perform(get("/api/landmarks/{landmarkId}/highest", 1L))
+            mockMvc.perform(get("/api/landmarks/{landmarkId}/highest", landmark.getId()))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.response.score").value(1000))
+                    .andExpect(jsonPath("$.response.score").value(score))
                     .andExpect(jsonPath("$.response.nickname").value(user.getNickname()))
                     .andExpect(jsonPath("$.response.profileBadge").value(user.getProfileBadge().name()))
                     .andDo(print());
-
-            // tear down
-            landmark.deleteRank();
-            landmarkRepository.save(landmark);
         }
 
         @Test
         @DisplayName("랜드마크에 최고점 유저가 없다면 빈 응답을 반환한다")
         void success_2() throws Exception {
+            // given
+            Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+            landmarkRepository.save(landmark);
+
             // expected
-            mockMvc.perform(get("/api/landmarks/{landmarkId}/highest", 1L))
+            mockMvc.perform(get("/api/landmarks/{landmarkId}/highest", landmark.getId()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.response").isEmpty())
                     .andDo(print());

--- a/src/test/java/com/playkuround/playkuroundserver/domain/score/api/LandmarkScoreRankApiTest.java
+++ b/src/test/java/com/playkuround/playkuroundserver/domain/score/api/LandmarkScoreRankApiTest.java
@@ -7,6 +7,7 @@ import com.playkuround.playkuroundserver.domain.adventure.domain.Adventure;
 import com.playkuround.playkuroundserver.domain.badge.domain.BadgeType;
 import com.playkuround.playkuroundserver.domain.landmark.dao.LandmarkRepository;
 import com.playkuround.playkuroundserver.domain.landmark.domain.Landmark;
+import com.playkuround.playkuroundserver.domain.landmark.domain.LandmarkType;
 import com.playkuround.playkuroundserver.domain.score.api.response.ScoreRankingResponse;
 import com.playkuround.playkuroundserver.domain.score.domain.ScoreType;
 import com.playkuround.playkuroundserver.domain.user.dao.UserRepository;
@@ -47,6 +48,7 @@ class LandmarkScoreRankApiTest {
     @AfterEach
     void clean() {
         adventureRepository.deleteAllInBatch();
+        landmarkRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
     }
 
@@ -54,8 +56,12 @@ class LandmarkScoreRankApiTest {
     @WithMockCustomUser
     @DisplayName("랭킹 유저가 한명도 없을 때")
     void getRankTop100ByLandmark_1() throws Exception {
+        // given
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
+
         // expected
-        mockMvc.perform(get("/api/scores/rank/{landmarkId}", 1))
+        mockMvc.perform(get("/api/scores/rank/{landmarkId}", landmark.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.response.rank").isEmpty())
@@ -69,7 +75,9 @@ class LandmarkScoreRankApiTest {
     @DisplayName("전체 유저 100명 미만 + 내 랭킹은 없음")
     void getRankTop100ByLandmark_2() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(1L).get();
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
+
         for (int i = 1; i <= 50; i++) {
             User user = TestUtil.createUser("user" + i + "@konkuk.ac.kr", "user" + i, Major.건축학부);
             userRepository.save(user);
@@ -79,11 +87,12 @@ class LandmarkScoreRankApiTest {
         }
 
         // when
-        MvcResult mvcResult = mockMvc.perform(get("/api/scores/rank/{landmarkId}", 1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isSuccess").value(true))
-                .andDo(print())
-                .andReturn();
+        MvcResult mvcResult =
+                mockMvc.perform(get("/api/scores/rank/{landmarkId}", landmark.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andDo(print())
+                        .andReturn();
         String json = mvcResult.getResponse().getContentAsString();
         ScoreRankingResponse response = TestUtil.convertFromJsonStringToObject(json, ScoreRankingResponse.class);
 
@@ -103,7 +112,9 @@ class LandmarkScoreRankApiTest {
     @DisplayName("전체 유저 100명 미만 + 내 랭킹 존재")
     void getRankTop100ByLandmark_3() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(1L).get();
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
+
         for (int i = 1; i <= 50; i++) {
             User user = TestUtil.createUser("user" + i + "@konkuk.ac.kr", "user" + i, Major.건축학부);
             userRepository.save(user);
@@ -111,16 +122,18 @@ class LandmarkScoreRankApiTest {
             Adventure adventure = new Adventure(user, landmark, ScoreType.CATCH, (long) i);
             adventureRepository.save(adventure);
         }
+
         User me = userRepository.findByEmail("test@konkuk.ac.kr").get();
         Adventure adventure = new Adventure(me, landmark, ScoreType.CATCH, 37L);
         adventureRepository.save(adventure);
 
         // when
-        MvcResult mvcResult = mockMvc.perform(get("/api/scores/rank/{landmarkId}", 1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isSuccess").value(true))
-                .andDo(print())
-                .andReturn();
+        MvcResult mvcResult =
+                mockMvc.perform(get("/api/scores/rank/{landmarkId}", landmark.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andDo(print())
+                        .andReturn();
         String json = mvcResult.getResponse().getContentAsString();
         ScoreRankingResponse response = TestUtil.convertFromJsonStringToObject(json, ScoreRankingResponse.class);
 
@@ -150,7 +163,9 @@ class LandmarkScoreRankApiTest {
     @DisplayName("전체 유저 100명 초과 + 내 랭킹 중간에 존재")
     void getRankTop100ByLandmark_4() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(1L).get();
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
+
         for (int i = 1; i <= 101; i++) {
             User user = TestUtil.createUser("user" + i + "@konkuk.ac.kr", "user" + i, Major.건축학부);
             userRepository.save(user);
@@ -158,12 +173,13 @@ class LandmarkScoreRankApiTest {
             Adventure adventure = new Adventure(user, landmark, ScoreType.CATCH, (long) i);
             adventureRepository.save(adventure);
         }
+
         User me = userRepository.findByEmail("test@konkuk.ac.kr").get();
         Adventure adventure = new Adventure(me, landmark, ScoreType.CATCH, 62L);
         adventureRepository.save(adventure);
 
         // when
-        MvcResult mvcResult = mockMvc.perform(get("/api/scores/rank/{landmarkId}", 1))
+        MvcResult mvcResult = mockMvc.perform(get("/api/scores/rank/{landmarkId}", landmark.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andDo(print())
@@ -197,7 +213,9 @@ class LandmarkScoreRankApiTest {
     @DisplayName("점수는 SUM으로 계산된 결과로 비교된다")
     void getRankTop100ByLandmark_5() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(1L).get();
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
+
         for (int i = 1; i <= 101; i++) {
             User user = TestUtil.createUser("user" + i + "@konkuk.ac.kr", "user" + i, Major.건축학부);
             userRepository.save(user);
@@ -205,11 +223,12 @@ class LandmarkScoreRankApiTest {
             adventureRepository.save(new Adventure(user, landmark, ScoreType.CATCH, (long) i));
             adventureRepository.save(new Adventure(user, landmark, ScoreType.BOOK, 1L));
         }
+
         User me = userRepository.findByEmail("test@konkuk.ac.kr").get();
         adventureRepository.save(new Adventure(me, landmark, ScoreType.CATCH, 62L));
 
         // when
-        MvcResult mvcResult = mockMvc.perform(get("/api/scores/rank/{landmarkId}", 1))
+        MvcResult mvcResult = mockMvc.perform(get("/api/scores/rank/{landmarkId}", landmark.getId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andDo(print())
@@ -243,7 +262,8 @@ class LandmarkScoreRankApiTest {
     @DisplayName("랭킹 조회 API에는 사용자 대표 뱃지 데이터가 포함되어 있다.")
     void getRankTop100ByLandmark_6() throws Exception {
         // given
-        Landmark landmark = landmarkRepository.findById(1L).get();
+        Landmark landmark = new Landmark(LandmarkType.경영관, 37.541, 127.079, 100);
+        landmarkRepository.save(landmark);
         {
             User me = userRepository.findByEmail("test@konkuk.ac.kr").get();
             adventureRepository.save(new Adventure(me, landmark, ScoreType.CATCH, 10L));
@@ -262,11 +282,12 @@ class LandmarkScoreRankApiTest {
         }
 
         // when
-        MvcResult mvcResult = mockMvc.perform(get("/api/scores/rank/{landmarkId}", 1))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.isSuccess").value(true))
-                .andDo(print())
-                .andReturn();
+        MvcResult mvcResult =
+                mockMvc.perform(get("/api/scores/rank/{landmarkId}", landmark.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andDo(print())
+                        .andReturn();
         String json = mvcResult.getResponse().getContentAsString();
         ScoreRankingResponse response = TestUtil.convertFromJsonStringToObject(json, ScoreRankingResponse.class);
 


### PR DESCRIPTION
## 요약
- AS-IS : `.sql` 파일로 landmark 초기 데이터 저장
- TO-BE : 테스트 메서드마다 given 절에서 직접 생성 및 저장하도록 변경